### PR TITLE
Add failing disconnect before connected test.

### DIFF
--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -19,6 +19,14 @@ const createClient = (opts = {}) => new StreamrClient({
 })
 
 describe('StreamrClient Connection', () => {
+    it('can disconnect before connected', async (done) => {
+        const client = createClient()
+        client.once('error', done)
+        client.connect()
+        await client.disconnect()
+        done()
+    })
+
     it('can reconnect after disconnect', (done) => {
         const client = createClient()
         client.on('error', done)


### PR DESCRIPTION
Perhaps this *should* fail, but currently it fails with an unhandled, uncatchable error, which is no good:

```
Unhandled "error" event. (Error: WebSocket was closed before the connection was established)
```

As a starting point, it should probably attach an error handler to `this.socket`.