### PR TITLE
Connection error events + autoconnect

### DIFF
--- a/src/Connection.js
+++ b/src/Connection.js
@@ -15,10 +15,6 @@ class Connection extends EventEmitter {
         this.options = options
         this.state = Connection.State.DISCONNECTED
         this.socket = socket
-
-        if (options.autoConnect) {
-            this.connect()
-        }
     }
 
     updateState(state) {
@@ -38,7 +34,12 @@ class Connection extends EventEmitter {
             })
         }
         if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
-            this.socket = new WebSocket(this.options.url)
+            try {
+                this.socket = new WebSocket(this.options.url)
+            } catch (err) {
+                this.emit('error', err)
+                return Promise.reject(err)
+            }
         }
         this.socket.binaryType = 'arraybuffer'
         this.socket.events = new EventEmitter()

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -89,6 +89,8 @@ export default class StreamrClient extends EventEmitter {
             (streamId) => this.getStream(streamId).catch((err) => this.emit('error', err)),
         )
 
+        this.on('error', () => this.disconnect().catch(() => {}))
+
         // Broadcast messages to all subs listening on stream
         this.connection.on(BroadcastMessage.TYPE, (msg) => {
             const stream = this.subscribedStreams[msg.streamMessage.getStreamId()]

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -89,7 +89,7 @@ export default class StreamrClient extends EventEmitter {
             (streamId) => this.getStream(streamId).catch((err) => this.emit('error', err)),
         )
 
-        this.on('error', () => this.disconnect().catch(() => {}))
+        this.on('error', () => this.ensureDisconnected())
 
         // Broadcast messages to all subs listening on stream
         this.connection.on(BroadcastMessage.TYPE, (msg) => {

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -54,7 +54,6 @@ describe('StreamrClient Connection', () => {
                 autoDisconnect: true,
             })
             client.once('error', async (error) => {
-                await client.disconnect()
                 expect(error).toBeTruthy()
                 done()
             })
@@ -95,7 +94,6 @@ describe('StreamrClient Connection', () => {
                 autoDisconnect: true,
             })
             client.once('error', async (error) => {
-                await client.disconnect()
                 expect(error).toBeTruthy()
                 done()
             })
@@ -186,8 +184,8 @@ describe('StreamrClient Connection', () => {
         })
         client.once('disconnected', () => {
             client.connect()
-            client.once('connected', () => {
-                client.disconnect()
+            client.once('connected', async () => {
+                await client.disconnect()
                 done()
             })
         })

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -34,6 +34,19 @@ describe('StreamrClient Connection', () => {
             await client.connect()
         })
 
+        it('rejects on connect without autoconnect', async (done) => {
+            const client = createClient({
+                url: 'asdasd',
+                autoConnect: false,
+                autoDisconnect: false,
+            })
+
+            await client.connect().catch(async (error) => {
+                expect(error).toBeTruthy()
+                done()
+            })
+        })
+
         it('emits error with autoconnect', (done) => {
             const client = createClient({
                 url: 'asdasd',
@@ -56,11 +69,23 @@ describe('StreamrClient Connection', () => {
                 autoDisconnect: false,
             })
             client.once('error', async (error) => {
-                await client.disconnect()
                 expect(error).toBeTruthy()
                 done()
             })
             await client.connect()
+        })
+
+        it('rejects on connect without autoconnect', async (done) => {
+            const client = createClient({
+                restUrl: 'asdasd',
+                autoConnect: false,
+                autoDisconnect: false,
+            })
+
+            await client.connect().catch(async (error) => {
+                expect(error).toBeTruthy()
+                done()
+            })
         })
 
         it('emits error with autoconnect', (done) => {

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -89,6 +89,16 @@ describe('StreamrClient Connection', () => {
                 done()
             })
         })
+    })
+
+    it('can disconnect before connected', async (done) => {
+        const client = createClient()
+        client.once('error', done)
+        client.connect()
+        await client.disconnect()
+        done()
+    })
+
     describe('ensureConnected', () => {
         it('connects the client', async () => {
             const client = createClient()
@@ -158,14 +168,6 @@ describe('StreamrClient Connection', () => {
         })
     })
 
-    it('can disconnect before connected', async (done) => {
-        const client = createClient()
-        client.once('error', done)
-        client.connect()
-        await client.disconnect()
-        done()
-    })
-
     describe('connect during disconnect', () => {
         let client
         async function teardown() {
@@ -187,7 +189,7 @@ describe('StreamrClient Connection', () => {
 
         it('can reconnect after disconnect', (done) => {
             client = createClient()
-            client.on('error', done)
+            client.once('error', done)
             client.connect()
             client.once('connected', () => {
                 client.disconnect()
@@ -196,6 +198,7 @@ describe('StreamrClient Connection', () => {
                 client.connect()
                 client.once('connected', async () => {
                     await client.disconnect()
+                    client.off('error', done)
                     done()
                 })
             })
@@ -206,6 +209,7 @@ describe('StreamrClient Connection', () => {
             client.once('error', done)
             client.connect()
             await client.disconnect()
+            client.off('error', done)
             done()
         })
 

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -19,6 +19,62 @@ const createClient = (opts = {}) => new StreamrClient({
 })
 
 describe('StreamrClient Connection', () => {
+    describe('bad config.url', () => {
+        it('emits error without autoconnect', async (done) => {
+            const client = createClient({
+                url: 'asdasd',
+                autoConnect: false,
+                autoDisconnect: false,
+            })
+            client.once('error', async (error) => {
+                await client.disconnect()
+                expect(error).toBeTruthy()
+                done()
+            })
+            await client.connect()
+        })
+
+        it('emits error with autoconnect', (done) => {
+            const client = createClient({
+                url: 'asdasd',
+                autoConnect: true,
+                autoDisconnect: true,
+            })
+            client.once('error', async (error) => {
+                await client.disconnect()
+                expect(error).toBeTruthy()
+                done()
+            })
+        })
+    })
+
+    describe('bad config.restUrl', () => {
+        it('emits error without autoconnect', async (done) => {
+            const client = createClient({
+                restUrl: 'asdasd',
+                autoConnect: false,
+                autoDisconnect: false,
+            })
+            client.once('error', async (error) => {
+                await client.disconnect()
+                expect(error).toBeTruthy()
+                done()
+            })
+            await client.connect()
+        })
+
+        it('emits error with autoconnect', (done) => {
+            const client = createClient({
+                restUrl: 'asdasd',
+                autoConnect: true,
+                autoDisconnect: true,
+            })
+            client.once('error', async (error) => {
+                await client.disconnect()
+                expect(error).toBeTruthy()
+                done()
+            })
+        })
     describe('ensureConnected', () => {
         it('connects the client', async () => {
             const client = createClient()
@@ -129,6 +185,14 @@ describe('StreamrClient Connection', () => {
 
         afterEach(async () => {
             await teardown()
+        })
+
+        it('can disconnect before connected', async (done) => {
+            client = createClient()
+            client.once('error', done)
+            client.connect()
+            await client.disconnect()
+            done()
         })
 
         it('can connect', async (done) => {


### PR DESCRIPTION
Currently this fails in two ways:

Clients with autoconnect + a badly formatted `config.url` will fail due to:

```
TypeError [ERR_INVALID_URL]: Invalid URL: asdasd?controlLayerVersion=1&messageLayerVersion=30
```

If `autoConnect` is false, this error will be emitted by the client, but without `autoConnect` the error is thrown.  This is because `connect` is called inside the constructor:

https://github.com/streamr-dev/streamr-client-javascript/blob/6d8580075dd012e429512c96b098fa305c97e8ac/src/Connection.js#L9-L22

I note if the user provides no url, it also causes a synchronous error to be thrown, which won't be emitted as an error. However this is fine because the behaviour doesn't change depending on the value of `autoConnect`. i.e. the main issue here is inconsistent failure behaviour between clients with and without `autoConnect`.

I also note that the `connect()` call succeeds, even though an error was emitted. `connect()` should probably reject in this case i.e.:

https://github.com/streamr-dev/streamr-client-javascript/blob/563e5b967102bfd2379055fbe424ffe17bedf057/test/integration/StreamrClient.test.js#L37-L48

----

Additionally, **the `autoConnect` behaviour seems at odds with what's [described in the readme](https://github.com/streamr-dev/streamr-client-javascript/blame/master/README.md#L87)**:

![image](https://user-images.githubusercontent.com/43438/55304980-ca69f700-5480-11e9-83d9-4d4da377c42c.png)

> connects automatically on the first call to subscribe()

Note that in these tests, there's no subscriptions, yet the `autoConnect` clients still try to `connect()` regardless whether there are any subscriptions? 

https://github.com/streamr-dev/streamr-client-javascript/blob/563e5b967102bfd2379055fbe424ffe17bedf057/test/integration/StreamrClient.test.js#L50-L60

Either the documentation is wrong, or the behaviour is wrong. I mean, how *can* there be subscriptions at construction time anyway, the client hasn't actually finished being constructed so no subscriptions can possibly be created for it yet.

**`Connection` should probably not know anything about `autoConnect`**, leave that to the client to manage. It already appears to do this:

https://github.com/streamr-dev/streamr-client-javascript/blob/6d8580075dd012e429512c96b098fa305c97e8ac/src/StreamrClient.js#L335-L337

I suggest either:
1. Removing the `autoConnect` line from the `Connection` constructor, to match the documentation (IMO this is preferred) or
2. Updating the documentation to report that it will connect immediately, and then changing the connection to wait for the current event loop to end before calling `connect` e.g. `Promise.resolve().then(this.connect)` or `setTimeout(() => this.connect(), 0)`. Even better if you want to go down this route would be to remove the `autoConnect` handling from the `Connection` and move the delayed `connect` call up into the client constructor.

Note it should be observed either change could break any existing client usage that relies on current `autoConnect` behaviour. This *is* a major version bump though so API breakage is acceptable, but this should probably be highlighted in release notes somewhere.

----

The second issue is that the client doesn't clean up its open connections on error. 

Originally I had these `client.disconnect()` calls in each test:

https://github.com/streamr-dev/streamr-client-javascript/blob/5682fadbbea5b1a1a3f108d31c793fa6cef1e603/test/integration/StreamrClient.test.js#L43-L47

This seemed to be required in order for the tests to exit cleanly without reporting there were handles left open:

```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

Note that without the `client.disconnect()`, the connection appears to hang open and the tests won't exit. Despite `client.isConnected()` reporting `false`, and the `client.disconnect()` call causing the same failure reported in #46, `client.disconnect()` is required.

I have since removed these disconnect calls because it's a workaround for the real issue of the client not cleaning up after itself on error.
