### PR TITLE
Don't emit event handler errors as error events.

### DIFF
--- a/src/Connection.js
+++ b/src/Connection.js
@@ -59,12 +59,14 @@ class Connection extends EventEmitter {
         })
 
         this.socket.onmessage = (messageEvent) => {
+            let controlMessage
             try {
-                const controlMessage = ControlLayer.ControlMessage.deserialize(messageEvent.data)
-                this.emit(controlMessage.type, controlMessage)
+                controlMessage = ControlLayer.ControlMessage.deserialize(messageEvent.data)
             } catch (err) {
                 this.emit('error', err)
+                return
             }
+            this.emit(controlMessage.type, controlMessage)
         }
 
         return new Promise((resolve) => {


### PR DESCRIPTION
Currently, exceptions that occur within connection event handlers are lifted up into connection error events. 

https://github.com/streamr-dev/streamr-client-javascript/blob/6d8580075dd012e429512c96b098fa305c97e8ac/src/Connection.js#L61-L68

This is probably not good behaviour to begin with and it messes with Jest's handling of failing tests. 

e.g. consider this:

```js
        it.only('client.subscription event handler fails', async (done) => {
            const sub = client.subscribe({
                stream: stream.id,
                resend: {
                    from: {
                        timestamp: 0,
                    },
                },
            }, () => {})
            sub.on('no_resend', () => {
                expect(true).toBe(false) // this throws, but jest's runner doesn't see the exception
                done()
            })
        })
```

The expectation fails, jest reports it, but "bizarrely" jest still waits for the test to time out:

```
❯ npx jest test/integration/StreamrClient.test.js
  console.error src/StreamrClient.js:234
    expect(received).toBe(expected) // Object.is equality

    Expected: false
    Received: true

 FAIL  test/integration/StreamrClient.test.js (17.572s)
  StreamrClient Connection
    ○ skipped 1 test
  StreamrClient
    Pub/Sub
      ✕ client.subscription event handler fails (16275ms)
      ○ skipped 6 tests

  ● StreamrClient › Pub/Sub › client.subscription event handler fails

    Timeout - Async callback was not invoked within the 15000ms timeout specified by jest.setTimeout.

      107 |         })
      108 |
    > 109 |         it.only('client.subscription event handler fails', async (done) => {
          |            ^
      110 |             const sub = client.subscribe({
      111 |                 stream: stream.id,
      112 |                 resend: {

      at Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:85:20)
      at Suite.only (test/integration/StreamrClient.test.js:109:12)

```

This happens because `expect` (or `assert`) throws an exception, this is run inside the event `emit` function, which is inside the `try/catch` so the exception gets lifted up into an `'error'` event, which Jest never sees, so Jest doesn't know the test has failed, so it waits and reports an async timeout? That this is what had occured was not immediately obvious to me and I've now wasted some time trying to track down an async behaviour bug which never existed. Perhaps could also be considered a bug in Jest.

Should only try catch around the minimal code:

https://github.com/streamr-dev/streamr-client-javascript/blob/f44209c04577c09526125949ed743d0b71575e22/src/Connection.js#L61-L70

Not quite sure how to write a test for this behaviour that can pass, since success requires an unhandled exception bubbling up to the top, but you'll see if you insert the above test into the suite, it will "fail normally" rather than waiting for async timeout.