### PR TITLE
Event order tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,47 @@ autoDisconnect | true  | If set to `true`, the client automatically disconnects
 
 ### Authentication options
 
-Option | Default value | Description
------- | ------------- | -----------
-auth.apiKey | null | Default API key to use to authenticate.
-auth.privateKey | null | Ethereum private key to use to authenticate.
-auth.provider | null | Ethereum provider used to connect to an account to use to authenticate.
-auth.username | null | Username to use to authenticate. Needs `auth.password` as well.
-auth.password | null | Password to use to authenticate. Needs `auth.username` as well.
-auth.sessionToken | null | Session token to authenticate directly without fetching a token with credentials. If the token expires, a new token cannot be retrieved.
+Authenticating with an API key (you can manage your API keys in the [Streamr web app](https://www.streamr.com)):
+```
+new StreamrClient({
+    auth: {
+        apiKey: 'your-api-key'
+    }
+})
+```
+Authenticating with an Ethereum private key by cryptographically signing a challenge (also automatically creates an associated user account):
+```
+new StreamrClient({
+    auth: {
+        privateKey: 'your-private-key'
+    }
+})
+```
+Authenticating with an Ethereum private key contained in an Ethereum (web3) provider:
+```
+new StreamrClient({
+    auth: {
+        provider: web3.currentProvider,
+    }
+})
+```
+(Authenticating with an username and password, for internal use by the Streamr app):
+```
+new StreamrClient({
+    auth: {
+        username: 'my@email.com',
+        password: 'password'
+    }
+})
+```
+(Authenticating with a pre-existing session token, for internal use by the Streamr app):
+```
+new StreamrClient({
+    auth: {
+        sessionToken: 'session-token'
+    }
+})
+```
 
 ### Message handler callback
 
@@ -104,8 +137,8 @@ The second argument to `client.subscribe(options, callback)` is the callback fun
 
 Argument | Description
 -------- | -----------
-message  | A javascript object containing the message itself
-metadata | Metadata for the message, for example `metadata.timestamp` etc.
+payload  | A JS object containing the message payload itself
+streamMessage | The whole [StreamMessage](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/message_layer/StreamMessage.js) object containing various metadata, for example `streamMessage.getTimestamp()` etc.
 
 ### StreamrClient object
 
@@ -164,7 +197,6 @@ Note that only one of the resend options can be used for a particular subscripti
 Name | Description
 ---- | -----------
 stream    | Stream id to subscribe to
-apiKey   | User key or stream key that authorizes the subscription. If defined, overrides the client's `apiKey`.
 partition | Partition number to subscribe to. Defaults to the default partition (0).
 resend | Object defining the resend options. Below are examples of its contents.
 
@@ -227,11 +259,11 @@ disconnected |  | Fired when the client has disconnected (or paused).
 
 Name | Handler Arguments | Description
 ---- | ----------------- | -----------
-subscribed | `{ from: number }` | Fired when a subscription request is acknowledged by the server.
-unsubscribed |  | Fired when an unsubscription is acknowledged by the server.
-resending |  | Fired when the subscription starts resending.
-resent |  | Fired after `resending` when the subscription has finished resending.
-no_resend |  | Fired after `resending` in case there was nothing to resend.
+subscribed | | Fired when a subscription request is acknowledged by the server.
+unsubscribed | | Fired when an unsubscription is acknowledged by the server.
+resending | [ResendResponseResending](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_resending/ResendResponseResendingV1.js) | Fired when the subscription starts resending. Followed by the `resent` event to mark completion of the resend after resent messages have been processed by the message handler function.
+resent | [ResendResponseResent](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_resent/ResendResponseResentV1.js) | Fired after `resending` when the subscription has finished resending.
+no_resend | [ResendResponseNoResend](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_no_resend/ResendResponseNoResendV1.js) | This will occur instead of the `resending` - `resent` sequence in case there were no messages to resend. 
 error | Error object | Reports errors, for example problems with message content 
 
 ### Logging

--- a/package-lock.json
+++ b/package-lock.json
@@ -7404,7 +7404,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -11393,8 +11392,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ethers": "^4.0.27",
     "eventemitter3": "^3.0.1",
     "node-fetch": "^2.1.2",
+    "once": "^1.4.0",
     "qs": "^6.6.0",
     "querystring": "^0.2.0",
     "randomstring": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "npm run build",
     "dev": "webpack --progress --colors --watch",
     "eslint": "eslint src/** test/**",
-    "test": "jest --detectOpenHandles",
+    "test": "npm run eslint && jest --detectOpenHandles",
     "test-unit": "jest --detectOpenHandles --forceExit test/unit",
     "test-integration": "jest --detectOpenHandles --forceExit --runInBand test/integration"
   },

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -24,7 +24,6 @@ import Subscription from './Subscription'
 import Connection from './Connection'
 import Session from './Session'
 import Signer from './Signer'
-import InvalidSignatureError from './errors/InvalidSignatureError'
 import SubscribedStream from './SubscribedStream'
 import Stream from './rest/domain/Stream'
 import FailedToPublishError from './errors/FailedToPublishError'
@@ -85,18 +84,10 @@ export default class StreamrClient extends EventEmitter {
         this.msgCreationUtil = new MessageCreationUtil(this.options.auth, this.signer, this.getUserInfo().catch((err) => this.emit('error', err)))
 
         // Broadcast messages to all subs listening on stream
-        this.connection.on(BroadcastMessage.TYPE, async (msg) => {
+        this.connection.on(BroadcastMessage.TYPE, (msg) => {
             const stream = this.subscribedStreams[msg.streamMessage.getStreamId()]
             if (stream) {
-                const valid = await stream.verifyStreamMessage(msg.streamMessage)
-                if (valid) {
-                    // Notify the Subscriptions for this stream. If this is not the message each individual Subscription
-                    // is expecting, they will either ignore it or request resend via gap event.
-                    stream.getSubscriptions().forEach((sub) => sub.handleMessage(msg.streamMessage, false))
-                } else {
-                    const error = new InvalidSignatureError(msg.streamMessage)
-                    stream.getSubscriptions().forEach((sub) => sub.handleError(error))
-                }
+                stream.getSubscriptions().forEach((sub) => sub.handleBroadcastMessage(msg.streamMessage, stream.verifyStreamMessage(msg.streamMessage)))
             } else {
                 debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
             }
@@ -108,12 +99,7 @@ export default class StreamrClient extends EventEmitter {
             if (stream) {
                 const sub = stream.getSubscription(msg.subId)
                 if (sub) {
-                    const valid = await stream.verifyStreamMessage(msg.streamMessage)
-                    if (valid) {
-                        sub.handleMessage(msg.streamMessage, true)
-                    } else {
-                        sub.handleError(new InvalidSignatureError(msg.streamMessage))
-                    }
+                    sub.handleResentMessage(msg.streamMessage, stream.verifyStreamMessage(msg.streamMessage))
                 } else {
                     debug('WARN: subscription not found for stream: %s, sub: %s', msg.streamMessage.getStreamId(), msg.subId)
                 }
@@ -149,7 +135,7 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(ResendResponseResending.TYPE, (response) => {
             const stream = this.subscribedStreams[response.streamId]
             if (stream && stream.getSubscription(response.subId)) {
-                stream.getSubscription(response.subId).emit('resending', [response.streamId, response.streamPartition, response.subId])
+                stream.getSubscription(response.subId).handleResending(response)
             } else {
                 debug('resent: Subscription %s is gone already', response.subId)
             }
@@ -158,7 +144,7 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(ResendResponseNoResend.TYPE, (response) => {
             const stream = this.subscribedStreams[response.streamId]
             if (stream && stream.getSubscription(response.subId)) {
-                stream.getSubscription(response.subId).emit('no_resend', [response.streamId, response.streamPartition, response.subId])
+                stream.getSubscription(response.subId).handleNoResend(response)
             } else {
                 debug('resent: Subscription %s is gone already', response.subId)
             }
@@ -167,7 +153,7 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(ResendResponseResent.TYPE, (response) => {
             const stream = this.subscribedStreams[response.streamId]
             if (stream && stream.getSubscription(response.subId)) {
-                stream.getSubscription(response.subId).emit('resent', [response.streamId, response.streamPartition, response.subId])
+                stream.getSubscription(response.subId).handleResent(response)
             } else {
                 debug('resent: Subscription %s is gone already', response.subId)
             }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -87,7 +87,10 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(BroadcastMessage.TYPE, (msg) => {
             const stream = this.subscribedStreams[msg.streamMessage.getStreamId()]
             if (stream) {
-                stream.getSubscriptions().forEach((sub) => sub.handleBroadcastMessage(msg.streamMessage, stream.verifyStreamMessage(msg.streamMessage)))
+                stream.getSubscriptions().forEach((sub) => sub.handleBroadcastMessage(
+                    msg.streamMessage,
+                    stream.verifyStreamMessage(msg.streamMessage),
+                ))
             } else {
                 debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
             }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -89,6 +89,7 @@ export default class StreamrClient extends EventEmitter {
             const stream = this.subscribedStreams[msg.streamMessage.getStreamId()]
             if (stream) {
                 const verifyFn = once(() => stream.verifyStreamMessage(msg.streamMessage)) // ensure verification occurs only once
+                // sub.handleBroadcastMessage never rejects: on any error it emits an 'error' event on the Subscription
                 stream.getSubscriptions().forEach((sub) => sub.handleBroadcastMessage(msg.streamMessage, verifyFn))
             } else {
                 debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
@@ -101,6 +102,7 @@ export default class StreamrClient extends EventEmitter {
             if (stream) {
                 const sub = stream.getSubscription(msg.subId)
                 if (sub) {
+                    // sub.handleResentMessage never rejects: on any error it emits an 'error' event on the Subscription
                     sub.handleResentMessage(
                         msg.streamMessage,
                         once(() => stream.verifyStreamMessage(msg.streamMessage)), // ensure verification occurs only once

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -133,7 +133,6 @@ export default class Subscription extends EventEmitter {
                 }
             })
         })
-
     }
 
     async handleNoResend(response) {

--- a/src/errors/VerificationFailedError.js
+++ b/src/errors/VerificationFailedError.js
@@ -1,0 +1,7 @@
+module.exports = class VerificationFailedError extends Error {
+    constructor(streamMessage, cause) {
+        super(`Verification failed for message: ${streamMessage.serialize()}, cause: ${cause}`)
+        this.streamMessage = streamMessage
+        this.cause = cause
+    }
+}

--- a/test/integration/Subscription.test.js
+++ b/test/integration/Subscription.test.js
@@ -1,0 +1,102 @@
+import { ethers } from 'ethers'
+import uniqueId from 'lodash/uniqueId'
+import StreamrClient from '../../src'
+import config from './config'
+
+const createClient = (opts = {}) => new StreamrClient({
+    url: config.websocketUrl,
+    restUrl: config.restUrl,
+    auth: {
+        privateKey: ethers.Wallet.createRandom().privateKey,
+    },
+    autoConnect: false,
+    autoDisconnect: false,
+    ...opts,
+})
+
+const throwError = (error) => { throw error }
+
+const RESEND_ALL = {
+    from: {
+        timestamp: 0,
+    },
+}
+
+describe('Subscription', () => {
+    let stream
+    let client
+    let subscription
+
+    async function setup() {
+        client = createClient()
+        client.on('error', throwError)
+        stream = await client.createStream({
+            name: uniqueId(),
+        })
+    }
+
+    async function teardown() {
+        if (stream) {
+            await stream.delete()
+            stream = undefined
+        }
+        if (subscription) {
+            await client.unsubscribe(subscription)
+            subscription = undefined
+        }
+        if (client && client.isConnected()) {
+            await client.disconnect()
+            client.off('error', throwError)
+            client = undefined
+        }
+    }
+
+    /**
+     * Returns an array which will be filled with subscription events in the order they occur.
+     * Needs to create subscription at same time in order to track message events.
+     */
+
+    function createMonitoredSubscription(opts = {}) {
+        const events = []
+        subscription = client.subscribe({
+            stream: stream.id,
+            resend: RESEND_ALL,
+            ...opts,
+        }, (message) => {
+            events.push(message)
+        })
+        subscription.on('subscribed', () => events.push('subscribed'))
+        subscription.on('resending', () => events.push('resending'))
+        subscription.on('resent', () => events.push('resent'))
+        subscription.on('unsubscribed', () => events.push('unsubscribed'))
+        subscription.on('error', () => events.push('unsubscribed'))
+        return events
+    }
+
+    beforeEach(async () => {
+        await teardown()
+        await setup()
+    })
+
+    afterEach(async () => {
+        await teardown()
+    })
+
+    describe('subscribe/unsubscribe events', () => {
+        it('fires events in correct order', async (done) => {
+            const subscriptionEvents = createMonitoredSubscription()
+            subscription.on('subscribed', async () => {
+                subscription.on('unsubscribed', () => {
+                    expect(subscriptionEvents).toEqual([
+                        'subscribed',
+                        'unsubscribed',
+                    ])
+                    done()
+                })
+                await client.unsubscribe(subscription)
+            })
+
+            await client.connect()
+        })
+    })
+})

--- a/test/integration/Subscription.test.js
+++ b/test/integration/Subscription.test.js
@@ -118,7 +118,6 @@ describe('Subscription', () => {
                 await wait(0)
                 expect(subscriptionEvents).toEqual([
                     'subscribed',
-                    'resending',
                     'no_resend',
                 ])
                 done()

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -360,7 +360,7 @@ describe('StreamrClient', () => {
                 let firstResult
                 sub.handleBroadcastMessage = (message, verifyFn) => {
                     firstResult = verifyFn()
-                    assert(firstResult instanceof Promise)
+                    assert(firstResult instanceof Promise, `firstResult is: ${firstResult}`)
                     assert.strictEqual(firstResult, verifyFn())
                 }
                 const sub2 = setupSubscription('stream1')

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -383,7 +383,6 @@ describe('StreamrClient', () => {
                 sub.handleResentMessage = sinon.stub().throws()
                 connection.emitMessage(msg(sub.streamId, {}, 'unknown subId'), 'unknown subId')
             })
-
         })
 
         describe('ResendResponseResending', () => {

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -47,9 +47,14 @@ describe('StreamrClient', () => {
         asyncs = []
     }
 
-    function setupSubscription(streamId, emitSubscribed = true, subscribeOptions = {}, handler = sinon.stub()) {
+    function setupSubscription(
+        streamId, emitSubscribed = true, subscribeOptions = {}, handler = sinon.stub(),
+        expectSubscribeRequest = !client.getSubscriptions(streamId).length,
+    ) {
         assert(client.isConnected(), 'setupSubscription: Client is not connected!')
-        connection.expect(SubscribeRequest.create(streamId))
+        if (expectSubscribeRequest) {
+            connection.expect(SubscribeRequest.create(streamId))
+        }
         const sub = client.subscribe({
             stream: streamId,
             ...subscribeOptions,
@@ -328,156 +333,118 @@ describe('StreamrClient', () => {
         })
 
         describe('BroadcastMessage', () => {
-            beforeEach(() => client.connect())
+            let sub
 
-            it('should call the message handler of each subscription', (done) => {
-                connection.expect(SubscribeRequest.create('stream1'))
+            beforeEach(async () => {
+                await client.connect()
+                sub = setupSubscription('stream1')
+            })
 
-                const counter = sinon.stub()
-                counter.onFirstCall().returns(1)
-                counter.onSecondCall().returns(2)
+            it('should call the message handler of each subscription', () => {
+                sub.handleBroadcastMessage = sinon.stub()
 
-                client.subscribe({
-                    stream: 'stream1',
-                }, () => {
-                    const c = counter()
-                    if (c === 2) {
-                        done()
-                    } else {
-                        assert.strictEqual(c, 1)
-                    }
-                })
-                client.subscribe({
-                    stream: 'stream1',
-                }, () => {
-                    const c = counter()
-                    if (c === 2) {
-                        done()
-                    } else {
-                        assert.strictEqual(c, 1)
-                    }
-                })
+                const sub2 = setupSubscription('stream1')
+                sub2.handleBroadcastMessage = sinon.stub()
 
-                connection.emitMessage(SubscribeRequest.create('stream1'))
-                connection.emitMessage(msg())
+                const msg1 = msg()
+                connection.emitMessage(msg1)
+
+                sinon.assert.calledWithMatch(sub.handleBroadcastMessage, msg1.streamMessage, sinon.match.instanceOf(Promise))
             })
 
             it('should not crash if messages are received for unknown streams', () => {
-                setupSubscription('stream1', true, {}, sinon.stub().throws())
                 connection.emitMessage(msg('unexpected-stream'))
-            })
-
-            it('does not mutate messages', (done) => {
-                const sentContent = {
-                    foo: 'bar',
-                }
-
-                const sub = setupSubscription('stream1', true, {}, (receivedContent) => {
-                    assert.deepEqual(sentContent, receivedContent)
-                    done()
-                })
-
-                connection.emitMessage(msg(sub.streamId, sentContent))
             })
         })
 
         describe('UnicastMessage', () => {
-            beforeEach(() => client.connect())
+            let sub
 
-            it('should call the message handler of specified Subscription', (done) => {
-                connection.expect(SubscribeRequest.create('stream1'))
+            beforeEach(async () => {
+                await client.connect()
+                sub = setupSubscription('stream1')
+            })
+
+            it('should call the message handler of specified Subscription', () => {
+                // this sub's handler must be called
+                sub.handleResentMessage = sinon.stub()
 
                 // this sub's handler must not be called
-                client.subscribe({
-                    stream: 'stream1',
-                }, sinon.stub().throws())
+                const sub2 = setupSubscription('stream1')
+                sub2.handleResentMessage = sinon.stub().throws()
 
-                // this sub's handler must be called
-                const sub2 = client.subscribe({
-                    stream: 'stream1',
-                }, () => {
-                    done()
-                })
+                const msg1 = msg(sub.streamId, {}, sub.id)
+                connection.emitMessage(msg1, sub.id)
 
-                connection.emitMessage(SubscribeResponse.create(sub2.streamId))
-                connection.emitMessage(msg(sub2.streamId, {}, sub2.id), sub2.id)
+                sinon.assert.calledWithMatch(sub.handleResentMessage, msg1.streamMessage, sinon.match.instanceOf(Promise))
             })
 
             it('ignores messages for unknown Subscriptions', () => {
-                const sub = setupSubscription('stream1', true, {}, sinon.stub().throws())
+                sub.handleResentMessage = sinon.stub().throws()
                 connection.emitMessage(msg(sub.streamId, {}, 'unknown subId'), 'unknown subId')
             })
 
-            it('does not mutate messages', (done) => {
-                const sentContent = {
-                    foo: 'bar',
-                }
-
-                const sub = setupSubscription('stream1', true, {}, (receivedContent) => {
-                    assert.deepEqual(sentContent, receivedContent)
-                    done()
-                })
-
-                connection.emitMessage(msg(sub.streamId, sentContent, sub.id), sub.id)
-            })
         })
 
         describe('ResendResponseResending', () => {
-            beforeEach(() => client.connect())
+            let sub
 
-            it('emits event on associated subscription', (done) => {
-                const sub = setupSubscription('stream1')
+            beforeEach(async () => {
+                await client.connect()
+                sub = setupSubscription('stream1')
+            })
+
+            it('emits event on associated subscription', () => {
+                sub.handleResending = sinon.stub()
                 const resendResponse = ResendResponseResending.create(sub.streamId, sub.streamPartition, sub.id)
-                sub.on('resending', (event) => {
-                    assert.deepEqual(event, [resendResponse.streamId, resendResponse.streamPartition, resendResponse.subId])
-                    done()
-                })
                 connection.emitMessage(resendResponse)
+                sinon.assert.calledWith(sub.handleResending, resendResponse)
             })
             it('ignores messages for unknown subscriptions', () => {
-                const sub = setupSubscription('stream1')
+                sub.handleResending = sinon.stub().throws()
                 const resendResponse = ResendResponseResending.create(sub.streamId, sub.streamPartition, 'unknown subid')
-                sub.on('resending', sinon.stub().throws())
                 connection.emitMessage(resendResponse)
             })
         })
 
         describe('ResendResponseNoResend', () => {
-            beforeEach(() => client.connect())
+            let sub
 
-            it('emits event on associated subscription', (done) => {
-                const sub = setupSubscription('stream1')
+            beforeEach(async () => {
+                await client.connect()
+                sub = setupSubscription('stream1')
+            })
+
+            it('calls event handler on subscription', () => {
+                sub.handleNoResend = sinon.stub()
                 const resendResponse = ResendResponseNoResend.create(sub.streamId, sub.streamPartition, sub.id)
-                sub.on('no_resend', (event) => {
-                    assert.deepEqual(event, [resendResponse.streamId, resendResponse.streamPartition, resendResponse.subId])
-                    done()
-                })
                 connection.emitMessage(resendResponse)
+                sinon.assert.calledWith(sub.handleNoResend, resendResponse)
             })
             it('ignores messages for unknown subscriptions', () => {
-                const sub = setupSubscription('stream1')
+                sub.handleNoResend = sinon.stub().throws()
                 const resendResponse = ResendResponseNoResend.create(sub.streamId, sub.streamPartition, 'unknown subid')
-                sub.on('no_resend', sinon.stub().throws())
                 connection.emitMessage(resendResponse)
             })
         })
 
         describe('ResendResponseResent', () => {
-            beforeEach(() => client.connect())
+            let sub
 
-            it('emits event on associated subscription', (done) => {
-                const sub = setupSubscription('stream1')
-                const resendResponse = ResendResponseResent.create(sub.streamId, sub.streamPartition, sub.id)
-                sub.on('resent', (event) => {
-                    assert.deepEqual(event, [resendResponse.streamId, resendResponse.streamPartition, resendResponse.subId])
-                    done()
-                })
-                connection.emitMessage(resendResponse)
+            beforeEach(async () => {
+                await client.connect()
+                sub = setupSubscription('stream1')
             })
-            it('ignores messages for unknown subscriptions', () => {
-                const sub = setupSubscription('stream1')
+
+            it('calls event handler on subscription', () => {
+                sub.handleResent = sinon.stub()
+                const resendResponse = ResendResponseResent.create(sub.streamId, sub.streamPartition, sub.id)
+                connection.emitMessage(resendResponse)
+                sinon.assert.calledWith(sub.handleResent, resendResponse)
+            })
+            it('does not call event handler for unknown subscriptions', () => {
+                sub.handleResent = sinon.stub().throws()
                 const resendResponse = ResendResponseResent.create(sub.streamId, sub.streamPartition, 'unknown subid')
-                sub.on('resent', sinon.stub().throws())
                 connection.emitMessage(resendResponse)
             })
         })

--- a/test/unit/Subscription.test.js
+++ b/test/unit/Subscription.test.js
@@ -47,9 +47,7 @@ describe('Subscription', () => {
                 })
 
                 describe('when message verification returns false', () => {
-                    it('does not call the message handler', async () => {
-                        return sub.handleBroadcastMessage(msg, sinon.stub().resolves(false))
-                    })
+                    it('does not call the message handler', async () => sub.handleBroadcastMessage(msg, sinon.stub().resolves(false)))
 
                     it('prints to standard error stream', async () => {
                         await sub.handleBroadcastMessage(msg, sinon.stub().resolves(false))
@@ -94,7 +92,6 @@ describe('Subscription', () => {
                         return sub.handleBroadcastMessage(msg, sinon.stub().resolves(true))
                     })
                 })
-
             })
 
             it('calls the callback once for each message in order', () => {
@@ -153,10 +150,8 @@ describe('Subscription', () => {
                 })
 
                 describe('when message verification returns false', () => {
-                    it('does not call the message handler', async () => {
-                        return sub.handleResentMessage(msg, sinon.stub()
-                            .resolves(false))
-                    })
+                    it('does not call the message handler', async () => sub.handleResentMessage(msg, sinon.stub()
+                        .resolves(false)))
 
                     it('prints to standard error stream', async () => {
                         await sub.handleResentMessage(msg, sinon.stub()
@@ -482,16 +477,29 @@ describe('Subscription', () => {
             assert.equal(handler.callCount, 2) // 2 == 1 resent message + 1 queued message
         })
 
-        it('cleans up the resend if event handler throws', async () => {
-            const handler = sinon.stub()
-            const sub = new Subscription(msg.getStreamId(), msg.getStreamPartition(), handler)
-            const error = new Error('test error, ignore')
-            sub.on('resent', sinon.stub().throws(error))
-            sub.setResending(true)
-            await sub.handleResentMessage(msg, sinon.stub().resolves(true))
+        describe('on error', () => {
+            let stdError
 
-            await sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
-            assert(!sub.isResending())
+            beforeEach(() => {
+                stdError = console.error
+                console.error = sinon.stub()
+            })
+
+            afterEach(() => {
+                console.error = stdError
+            })
+
+            it('cleans up the resend if event handler throws', async () => {
+                const handler = sinon.stub()
+                const sub = new Subscription(msg.getStreamId(), msg.getStreamPartition(), handler)
+                const error = new Error('test error, ignore')
+                sub.on('resent', sinon.stub().throws(error))
+                sub.setResending(true)
+                await sub.handleResentMessage(msg, sinon.stub().resolves(true))
+
+                await sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
+                assert(!sub.isResending())
+            })
         })
     })
 
@@ -515,13 +523,27 @@ describe('Subscription', () => {
             assert.equal(handler.callCount, 1)
         })
 
-        it('cleans up the resend if event handler throws', async () => {
-            const sub = new Subscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
-            const error = new Error('test error, ignore')
-            sub.on('no_resend', sinon.stub().throws(error))
-            sub.setResending(true)
-            await sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'subId'))
-            assert(!sub.isResending())
+        describe('on error', () => {
+            let stdError
+
+            beforeEach(() => {
+                stdError = console.error
+                console.error = sinon.stub()
+            })
+
+            afterEach(() => {
+                console.error = stdError
+            })
+
+            it('cleans up the resend if event handler throws', async () => {
+                const sub = new Subscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
+                const error = new Error('test error, ignore')
+                sub.on('no_resend', sinon.stub()
+                    .throws(error))
+                sub.setResending(true)
+                await sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'subId'))
+                assert(!sub.isResending())
+            })
         })
     })
 })


### PR DESCRIPTION
This adds failing tests for subscription event ordering.

The resent message events should probably be emitted before the final `resent` event happens, currently it seems to always send `resending`, `resent` *before* the resent messages are emitted.

Also, currently readme says `resending` will be sent before `no_resend`:
![image](https://user-images.githubusercontent.com/43438/55309361-25571a80-5490-11e9-8fcd-a15025ac6382.png)

This doesn't seem to happen, `resending` only seems to fire before a `resent` event.

----

Additionally, I'm seeing the following 500 errors in my local tests:

```

  ● Subscription › resending/resent events › fires events in correct order

    Request to http://localhost:8081/streamr-core/api/v1/streams/KgXNomPJT9KtRF1rWVKSTA returned with error code 500: {"code":"MySQLTransactionRollbackException","message":"Deadlock found when trying to get lock; try restarting transaction"}

      34 |         return authFetch(url, session, opts, true)
      35 |     } else {
    > 36 |         throw new Error(`Request to ${url} returned with error code ${res.status}: ${text}`)
         |               ^
      37 |     }
      38 | }
      39 |
```

```
● Subscription › resending/resent events › fires events in correct order

    Request to http://localhost:8081/streamr-core/api/v1/streams/nB4vyhQtSyy5PeD-UCYPGA returned with error code 500: {"code":"StaleObjectStateException","message":"Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect): [com.unifina.domain.security.Permission#6240]"}

      34 |         return authFetch(url, session, opts, true)
      35 |     } else {
    > 36 |         throw new Error(`Request to ${url} returned with error code ${res.status}: ${text}`)
         |               ^
      37 |     }
      38 | }
      39 |

      at _callee$ (src/rest/utils.js:36:15)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:296:22)
      at Generator.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:114:21)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:28:13
```

These don't occur if tests are run individually and seem to stem from this test teardown code:

https://github.com/streamr-dev/streamr-client-javascript/blob/f5c95d5415903b617fcd47a1bacc6a87af188ebb/test/integration/Subscription.test.js#L39-L53