### PR TITLE
Log error object so stack trace is visible

### DIFF
--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -216,7 +216,7 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(ErrorResponse.TYPE, (err) => {
             const errorObject = new Error(err.errorMessage)
             this.emit('error', errorObject)
-            console.error(errorObject.message)
+            console.error(errorObject)
         })
 
         this.connection.on('error', (err) => {
@@ -231,7 +231,7 @@ export default class StreamrClient extends EventEmitter {
             } else {
                 const errorObject = err instanceof Error ? err : new Error(err)
                 this.emit('error', errorObject)
-                console.error(errorObject.message)
+                console.error(errorObject)
             }
         })
     }


### PR DESCRIPTION
Logging `error.message` loses the error's stack trace, making it impossible to see where error messages originate from without opening a debugger.

e.g.

```
> console.log(new Error('message').message)
message
```

```
> console.log(new Error('message'))
Error: message
    at repl:1:13
    at ContextifyScript.Script.runInThisContext (vm.js:50:33)
    at REPLServer.defaultEval (repl.js:240:29)
    at bound (domain.js:301:14)
    at REPLServer.runBound [as eval] (domain.js:314:12)
    at REPLServer.onLine (repl.js:468:10)
    at emitOne (events.js:121:20)
    at REPLServer.emit (events.js:211:7)
    at REPLServer.Interface._onLine (readline.js:280:10)
    at REPLServer.Interface._line (readline.js:629:8)
undefined
>
```