### PR TITLE
Add failing test for trying to connect() during a disconnect().

### DIFF
--- a/src/Connection.js
+++ b/src/Connection.js
@@ -32,6 +32,14 @@ class Connection extends EventEmitter {
         } else if (this.state === Connection.State.CONNECTED) {
             return Promise.reject(new Error('Already connected!'))
         }
+        if (this.state === Connection.State.DISCONNECTING) {
+            return new Promise((resolve) => {
+                this.once('disconnected', async () => {
+                    await this.connect()
+                    resolve()
+                })
+            })
+        }
         if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
             this.socket = new WebSocket(this.options.url)
         }
@@ -81,6 +89,14 @@ class Connection extends EventEmitter {
             return Promise.reject(new Error('Already disconnected!'))
         } else if (this.socket === undefined) {
             return Promise.reject(new Error('Something is wrong: socket is undefined!'))
+        }
+        if (this.state === Connection.State.CONNECTING) {
+            return new Promise((resolve) => {
+                this.once('connected', async () => {
+                    await this.disconnect()
+                    resolve()
+                })
+            })
         }
 
         return new Promise((resolve) => {

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -34,10 +34,7 @@ class Connection extends EventEmitter {
         }
         if (this.state === Connection.State.DISCONNECTING) {
             return new Promise((resolve) => {
-                this.once('disconnected', async () => {
-                    await this.connect()
-                    resolve()
-                })
+                this.once('disconnected', () => resolve(this.connect()))
             })
         }
         if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
@@ -92,10 +89,7 @@ class Connection extends EventEmitter {
         }
         if (this.state === Connection.State.CONNECTING) {
             return new Promise((resolve) => {
-                this.once('connected', async () => {
-                    await this.disconnect()
-                    resolve()
-                })
+                this.once('connected', () => resolve(this.disconnect()))
             })
         }
 

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -119,7 +119,7 @@ describe('StreamrClient Connection', () => {
                 // wait for possible reconnections
                 setTimeout(() => {
                     client.off('connecting', onConnecting)
-                    expect(client.isConnected()).toBeFalse()
+                    expect(client.isConnected()).toBe(false)
                     done()
                 }, 2000)
             })

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -51,15 +51,28 @@ describe('StreamrClient Connection', () => {
                 'connecting',
                 'connected',
                 'disconnecting',
-                'disconnected',
+                'disconnected', // should disconnect before re-connecting
                 'connecting',
                 'connected',
             ])
-            done()
+            // ensure 'Connection lost. Attempting to reconnect' doesn't happen
+            const onConnecting = () => {
+                done(new Error('should not be connecting'))
+            }
+
+            client.once('connecting', onConnecting)
+
+            await client.disconnect()
+
+            setTimeout(() => {
+                client.off('connecting', onConnecting)
+                expect(client.isConnected()).toBeFalse()
+                done()
+            }, 2000)
         })
 
         disconnected = client.disconnect()
-    })
+    }, 10000)
 })
 
 describe('StreamrClient', () => {

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -34,6 +34,32 @@ describe('StreamrClient Connection', () => {
             })
         })
     })
+
+    it('can connect during disconnect', async (done) => {
+        const client = createClient()
+        const connectionEventSpy = jest.spyOn(client.connection, 'emit')
+        let disconnected
+
+        await client.connect()
+
+        client.connection.once('disconnecting', async () => {
+            const connected = client.connect()
+            await disconnected // ensure original disconnect() actually resolved
+            await connected
+            const eventNames = connectionEventSpy.mock.calls.map(([eventName]) => eventName)
+            expect(eventNames).toEqual([
+                'connecting',
+                'connected',
+                'disconnecting',
+                'disconnected',
+                'connecting',
+                'connected',
+            ])
+            done()
+        })
+
+        disconnected = client.disconnect()
+    })
 })
 
 describe('StreamrClient', () => {

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -35,44 +35,97 @@ describe('StreamrClient Connection', () => {
         })
     })
 
-    it('can connect during disconnect', async (done) => {
-        const client = createClient()
-        const connectionEventSpy = jest.spyOn(client.connection, 'emit')
-        let disconnected
-
-        await client.connect()
-
-        client.connection.once('disconnecting', async () => {
-            const connected = client.connect()
-            await disconnected // ensure original disconnect() actually resolved
-            await connected
-            const eventNames = connectionEventSpy.mock.calls.map(([eventName]) => eventName)
-            expect(eventNames).toEqual([
-                'connecting',
-                'connected',
-                'disconnecting',
-                'disconnected', // should disconnect before re-connecting
-                'connecting',
-                'connected',
-            ])
-            // ensure 'Connection lost. Attempting to reconnect' doesn't happen
-            const onConnecting = () => {
-                done(new Error('should not be connecting'))
+    describe('connect during disconnect', () => {
+        let client
+        async function teardown() {
+            if (client) {
+                if (client.connection.state !== 'disconnected') {
+                    await client.disconnect()
+                }
+                client = undefined
             }
+        }
 
-            client.once('connecting', onConnecting)
-
-            await client.disconnect()
-
-            setTimeout(() => {
-                client.off('connecting', onConnecting)
-                expect(client.isConnected()).toBeFalse()
-                done()
-            }, 2000)
+        beforeEach(async () => {
+            await teardown()
         })
 
-        disconnected = client.disconnect()
-    }, 10000)
+        afterEach(async () => {
+            await teardown()
+        })
+
+        it('can connect', async (done) => {
+            client = createClient()
+            await client.connect()
+
+            client.connection.once('disconnecting', async () => {
+                await client.connect()
+                await client.disconnect()
+                done()
+            })
+
+            client.disconnect()
+        }, 5000)
+
+        it('will resolve original disconnect', async (done) => {
+            client = createClient()
+
+            await client.connect()
+
+            client.connection.once('disconnecting', async () => {
+                await client.connect()
+            })
+            await client.disconnect()
+            done() // ok if it ever gets here
+        }, 5000)
+
+        it('has connection state transitions in correct order', async (done) => {
+            client = createClient()
+            const connectionEventSpy = jest.spyOn(client.connection, 'emit')
+
+            await client.connect()
+
+            client.connection.once('disconnecting', async () => {
+                await client.connect()
+                const eventNames = connectionEventSpy.mock.calls.map(([eventName]) => eventName)
+                expect(eventNames).toEqual([
+                    'connecting',
+                    'connected',
+                    'disconnecting',
+                    'disconnected', // should disconnect before re-connecting
+                    'connecting',
+                    'connected',
+                ])
+                done()
+            })
+            await client.disconnect()
+        }, 5000)
+
+        it('does not try to reconnect', async (done) => {
+            client = createClient()
+
+            await client.connect()
+
+            client.connection.once('disconnecting', async () => {
+                await client.connect()
+
+                // should not try connecting after disconnect (or any other reason)
+                const onConnecting = () => {
+                    done(new Error('should not be connecting'))
+                }
+                client.once('connecting', onConnecting)
+
+                client.disconnect()
+                // wait for possible reconnections
+                setTimeout(() => {
+                    client.off('connecting', onConnecting)
+                    expect(client.isConnected()).toBeFalse()
+                    done()
+                }, 2000)
+            })
+            client.disconnect()
+        }, 6000)
+    })
 })
 
 describe('StreamrClient', () => {


### PR DESCRIPTION
Related to [this comment](https://github.com/streamr-dev/streamr-client-javascript/pull/51#discussion_r270842258) on #51.

Currently if `connect()` is called while it's in a `DISCONNECTING` state, the new connect never completes.

e.g. https://github.com/streamr-dev/streamr-client-javascript/blob/9f9d86a4f2024fb790397070ee9c186b430d87cf/test/integration/StreamrClient.test.js#L57-L68

The above code never gets past the `await client.connect()` inside `.on('disconnecting')`.

The sequence of state transitions for the connection goes like:

1. `CONNECTING`
2. `CONNECTED`
3. `DISCONNECTING`
4. `CONNECTING`
5. `DISCONNECTED`
6. `CONNECTING`

The final `CONNECTING` is caused by this code, not clear yet whether this is also the cause of the inability to reconnect:

https://github.com/streamr-dev/streamr-client-javascript/blob/89a261d38cc46f18c09e10e3f10bf316059dd76c/src/Connection.js#L50-L59

So IIUC the scenario goes something like this:

1. `client.disconnect()` is called (due to subscriptions empty or an explicit call)
2. While in `DISCONNECTING` state `client.connect()` is called e.g. `client.subscribe()` was called again
3. State now moves from `DISCONNECTING` to `CONNECTING`. This replaces the websocket but doesn't unsubscribe the old socket listeners.
4. Original websocket can possibly close before the new connect completes. The original socket `close` event handler (above) fires.
5. State is not `DISCONNECTING`, it's `CONNECTING`, so it (mis)reports to `debug` "connection lost, reconnecting", sets the connection state from `CONNECTING` to `DISCONNECTED` and queues a `connect()` call for 2 seconds from now.
6. The original connect (should) complete, now moving the state directly from `DISCONNECTED` to `CONNECTED` 🤷‍♀️ (though currently this `CONNECTED` never happens)
7. And to top it off, `connect()` gets called again in two seconds which will forcibly try reconnect the client even if the user had explicitly called `disconnect()` or it had itself auto-disconnected due to no subscriptions. Also possible this could be the `connect()` call that triggers this whole sequence (again) at step 2.