### PR TITLE
StreamrClient#publish: queue size limit & resolving when published

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ publishWithSignature | 'auto' | Determines if data points published to streams a
 verifySignatures | 'auto' | Determines under which conditions signed and unsigned data points are accepted or rejected. 'always' accepts only signed and verified data points. 'never' accepts all data points. 'auto' verifies all signed data points before accepting them and accepts unsigned data points only for streams not supposed to contain signed data.
 autoConnect | true | If set to `true`, the client connects automatically on the first call to `subscribe()`. Otherwise an explicit call to `connect()` is required.
 autoDisconnect | true  | If set to `true`, the client automatically disconnects when the last stream is unsubscribed. Otherwise the connection is left open and can be disconnected explicitly by calling `disconnect()`.
+maxPublishQueueSize | 10000 | Only in effect when `autoConnect = true`. Controls the maximum number of messages to retain in internal queue when client has disconnected and is reconnecting to Streamr.
 
 ### Authentication options
 

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -189,11 +189,13 @@ export default class StreamrClient extends EventEmitter {
             // Check pending publish requests
             const publishQueueCopy = this.publishQueue.slice(0)
             this.publishQueue = []
-            publishQueueCopy.forEach((args) => {
-                this.publish(...args).catch((err) => {
-                    debug(`Error: ${err}`)
-                    this.emit(err)
-                })
+            publishQueueCopy.forEach(([streamId, data, timestamp, partitionKey, resolve, reject]) => {
+                this.publish(streamId, data, timestamp, partitionKey).then(resolve)
+                    .catch((err) => {
+                        debug(`Error: ${err}`)
+                        this.emit(err)
+                        reject(err)
+                    })
             })
         })
 


### PR DESCRIPTION
Two changes in two separate commits regarding `StreamrClient#publish`. Please give feedback.

1. If, for whatever reason, streamr-client is unable to (re-)establish connection to Data API then `maxPublishQueueSize` prevents queue from growing without bounds.

2. If invoking `publish` while streamr-client is disconnected from Data API wait for publishing to occur before resolving Promise.