### PR TITLE
Add connection convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ streamMessage | The whole [StreamMessage](https://github.com/streamr-dev/streamr
 
 Name | Description
 ---- | -----------
-connect() | Connects to the server, and also subscribes to any streams for which `subscribe()` has been called before calling `connect()`.
-disconnect() | Disconnects from the server, clearing all subscriptions.
+connect() | Connects to the server, and also subscribes to any streams for which `subscribe()` has been called before calling `connect()`. Returns a Promise. Rejects if already connected or connecting.
+disconnect() | Disconnects from the server, clearing all subscriptions. Returns a Promise.  Rejects if already disconnected or disconnecting.
 pause() | Disconnects from the server without clearing subscriptions.
+ensureConnected() | Safely connects if not connected. Returns a promise. Resolves immediately if already connected. Only rejects if an error occurs during connection.
+ensureDisconnected() | Safely disconnects if not disconnected. Returns a promise. Resolves immediately if already disconnected. Only rejects if an error occurs during disconnection.
 
 #### Managing subscriptions
 
@@ -172,7 +174,7 @@ createStream(properties) | Creates a Stream with the given properties. For more 
 getOrCreateStream(properties) | Gets a Stream with the id or name given in `properties`, or creates it if one is not found.
 publish(streamId, message) | Publishes a new message (data point) to the given Stream.
 
-#### Listening to state changes of the client 
+#### Listening to state changes of the client
 
 on(eventName, function) | Binds a `function` to an event called `eventName`
 once(eventName, function) | Binds a `function` to an event called `eventName`. It gets called once and then removed.
@@ -263,8 +265,8 @@ subscribed | | Fired when a subscription request is acknowledged by the server.
 unsubscribed | | Fired when an unsubscription is acknowledged by the server.
 resending | [ResendResponseResending](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_resending/ResendResponseResendingV1.js) | Fired when the subscription starts resending. Followed by the `resent` event to mark completion of the resend after resent messages have been processed by the message handler function.
 resent | [ResendResponseResent](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_resent/ResendResponseResentV1.js) | Fired after `resending` when the subscription has finished resending.
-no_resend | [ResendResponseNoResend](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_no_resend/ResendResponseNoResendV1.js) | This will occur instead of the `resending` - `resent` sequence in case there were no messages to resend. 
-error | Error object | Reports errors, for example problems with message content 
+no_resend | [ResendResponseNoResend](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_no_resend/ResendResponseNoResendV1.js) | This will occur instead of the `resending` - `resent` sequence in case there were no messages to resend.
+error | Error object | Reports errors, for example problems with message content
 
 ### Logging
 

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -29,6 +29,7 @@ import SubscribedStream from './SubscribedStream'
 import Stream from './rest/domain/Stream'
 import FailedToPublishError from './errors/FailedToPublishError'
 import MessageCreationUtil from './MessageCreationUtil'
+import { waitFor } from './utils'
 
 export default class StreamrClient extends EventEmitter {
     constructor(options, connection) {
@@ -340,7 +341,7 @@ export default class StreamrClient extends EventEmitter {
         if (this.connection.state !== Connection.State.CONNECTING) {
             return this.connect()
         }
-        return this.waitFor('connected')
+        return waitFor(this, 'connected')
     }
 
     async ensureDisconnected() {
@@ -348,29 +349,7 @@ export default class StreamrClient extends EventEmitter {
         if (this.connection.state !== Connection.State.DISCONNECTING) {
             return this.disconnect()
         }
-        return this.waitFor('disconnected')
-    }
-
-    /**
-     * Converts a .once event listener into a promise.
-     * Rejects if an 'error' event is received before resolving.
-     */
-
-    waitFor(event) {
-        return new Promise((resolve, reject) => {
-            let onError
-            const onEvent = (value) => {
-                this.off('error', onError)
-                resolve(value)
-            }
-            onError = (error) => {
-                this.off(event, onEvent)
-                reject(error)
-            }
-
-            this.once(event, onEvent)
-            this.once('error', onError)
-        })
+        return waitFor(this, 'disconnected')
     }
 
     unsubscribe(sub) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,21 @@
+/**
+ * Converts a .once event listener into a promise.
+ * Rejects if an 'error' event is received before resolving.
+ */
+
+export function waitFor(emitter, event) {
+    return new Promise((resolve, reject) => {
+        let onError
+        const onEvent = (value) => {
+            emitter.off('error', onError)
+            resolve(value)
+        }
+        onError = (error) => {
+            emitter.off(event, onEvent)
+            reject(error)
+        }
+
+        emitter.once(event, onEvent)
+        emitter.once('error', onError)
+    })
+}

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -63,14 +63,14 @@ describe('StreamrClient Connection', () => {
             await client.ensureDisconnected()
             await client.connect()
             await client.ensureDisconnected()
-            expect(client.isConnected()).toBeFalsy()
+            expect(client.isDisconnected()).toBeTruthy()
         })
 
         it('does not error if disconnecting', async (done) => {
             const client = createClient()
             client.connection.once('disconnecting', async () => {
                 await client.ensureDisconnected()
-                expect(client.isConnected()).toBeFalsy()
+                expect(client.isDisconnected()).toBeTruthy()
                 done()
             })
             await client.connect()
@@ -81,7 +81,7 @@ describe('StreamrClient Connection', () => {
             const client = createClient()
             client.connection.once('connecting', async () => {
                 await client.ensureDisconnected()
-                expect(client.isConnected()).toBeFalsy()
+                expect(client.isDisconnected()).toBeTruthy()
                 done()
             })
             await client.connect()

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -19,6 +19,75 @@ const createClient = (opts = {}) => new StreamrClient({
 })
 
 describe('StreamrClient Connection', () => {
+    describe('ensureConnected', () => {
+        it('connects the client', async () => {
+            const client = createClient()
+            await client.ensureConnected()
+            expect(client.isConnected()).toBeTruthy()
+            // no error if already connected
+            await client.ensureConnected()
+            expect(client.isConnected()).toBeTruthy()
+            await client.disconnect()
+        })
+
+        it('does not error if connecting', async (done) => {
+            const client = createClient()
+            client.connection.once('connecting', async () => {
+                await client.ensureConnected()
+                expect(client.isConnected()).toBeTruthy()
+                await client.disconnect()
+                done()
+            })
+
+            await client.connect()
+        })
+
+        it('connects if disconnecting', async (done) => {
+            const client = createClient()
+            client.connection.once('disconnecting', async () => {
+                await client.ensureConnected()
+                expect(client.isConnected()).toBeTruthy()
+                await client.disconnect()
+                done()
+            })
+
+            await client.connect()
+            await client.disconnect()
+        })
+    })
+
+    describe('ensureDisconnected', () => {
+        it('disconnects the client', async () => {
+            const client = createClient()
+            // no error if already disconnected
+            await client.ensureDisconnected()
+            await client.connect()
+            await client.ensureDisconnected()
+            expect(client.isConnected()).toBeFalsy()
+        })
+
+        it('does not error if disconnecting', async (done) => {
+            const client = createClient()
+            client.connection.once('disconnecting', async () => {
+                await client.ensureDisconnected()
+                expect(client.isConnected()).toBeFalsy()
+                done()
+            })
+            await client.connect()
+            await client.disconnect()
+        })
+
+        it('disconnects if connecting', async (done) => {
+            const client = createClient()
+            client.connection.once('connecting', async () => {
+                await client.ensureDisconnected()
+                expect(client.isConnected()).toBeFalsy()
+                done()
+            })
+            await client.connect()
+        })
+    })
+
     it('can disconnect before connected', async (done) => {
         const client = createClient()
         client.once('error', done)


### PR DESCRIPTION
This PR adds the following convenience methods:

* `ensureConnected` resolves if/when client is next connected. Calls connect if needed & safe to do so.

https://github.com/streamr-dev/streamr-client-javascript/blob/b13147c23becab0181848986864de21dca3e9964/src/StreamrClient.js#L417-L423

* `ensureDisconnected` resolves if/when client is next disconnected. Calls disconnect if needed & safe to do so.

https://github.com/streamr-dev/streamr-client-javascript/blob/b13147c23becab0181848986864de21dca3e9964/src/StreamrClient.js#L431-L437

This should reduce the easily forgotten requirement to verify which of the four possible states the connection is currently in before calling `connect` or `disconnect` making sure to wait for pending actions to complete, and responding to error events that occur in the process.

Method names inspired by existing helper in test:

https://github.com/streamr-dev/streamr-client-javascript/blob/f71e23e446b17ee9e349d865026924fd8c991575/test/integration/StreamrClient.test.js#L153-L156

----

Also fills in a few other self-explanatory connection state checks to go alongside the `isConnected` method:

* `isDisconnected`
* `isConnecting`
* `isDisconnecting`

https://github.com/streamr-dev/streamr-client-javascript/blob/b13147c23becab0181848986864de21dca3e9964/src/StreamrClient.js#L375-L385

Will add docs for the above to the Readme if you believe this should be considered part of the public API.

----

PR also adds a utility `waitFor` which returns a promise that resolves/rejects when a specific event occurs or an error event, whichever comes first. e.g. 

```js
// resolves when next connected event occurs, or rejects if an error is emitted first
await waitFor(client, 'connected')
```

https://github.com/streamr-dev/streamr-client-javascript/blob/b13147c23becab0181848986864de21dca3e9964/src/utils.js#L7-L20

All of the above probably eventually belongs in `Connection`, but let's take small steps.

----

Note PR base is #51.