### PR TITLE
Handle disconnecting during publish.

### DIFF
--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -268,6 +268,18 @@ export default class StreamrClient extends EventEmitter {
         // If connected, emit a publish request
         if (this.isConnected()) {
             const streamMessage = await this.msgCreationUtil.createStreamMessage(streamObjectOrId, data, timestamp, partitionKey)
+            // if happened to disconnect before completed
+            if (!this.isConnected()) {
+                if (this.options.autoConnect) {
+                    // try reconnect if autoConnect
+                    return this.publish(streamId, data, timestamp, partitionKey)
+                }
+                throw new FailedToPublishError(
+                    streamId,
+                    data,
+                    'Disconnected before publish completed',
+                )
+            }
             return this._requestPublish(streamMessage, sessionToken)
         } else if (this.options.autoConnect) {
             if (this.publishQueue.length >= this.options.maxPublishQueueSize) {

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -224,7 +224,8 @@ export default class StreamrClient extends EventEmitter {
                     debug('WARN: InvalidJsonError received for stream with no subscriptions: %s', err.streamId)
                 }
             } else {
-                const errorObject = err instanceof Error ? err : new Error(err)
+                // if it looks like an error emit as-is, otherwise wrap in new Error
+                const errorObject = (err && err.stack && err.message) ? err : new Error(err)
                 this.emit('error', errorObject)
                 console.error(errorObject)
             }

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -2,6 +2,8 @@ import assert from 'assert'
 import fetch from 'node-fetch'
 import { MessageLayer } from 'streamr-client-protocol'
 import { ethers } from 'ethers'
+import uniqueId from 'lodash/uniqueId'
+
 import StreamrClient from '../../src'
 import config from './config'
 
@@ -172,9 +174,8 @@ describe('StreamrClient Connection', () => {
         let client
         async function teardown() {
             if (client) {
-                if (client.connection.state !== 'disconnected') {
-                    await client.disconnect()
-                }
+                client.removeAllListeners('error')
+                await client.ensureDisconnected()
                 client = undefined
             }
         }
@@ -198,7 +199,6 @@ describe('StreamrClient Connection', () => {
                 client.connect()
                 client.once('connected', async () => {
                     await client.disconnect()
-                    client.off('error', done)
                     done()
                 })
             })
@@ -209,7 +209,6 @@ describe('StreamrClient Connection', () => {
             client.once('error', done)
             client.connect()
             await client.disconnect()
-            client.off('error', done)
             done()
         })
 
@@ -285,6 +284,97 @@ describe('StreamrClient Connection', () => {
             client.disconnect()
         }, 6000)
     })
+
+    describe('publish connection handling', () => {
+        let client
+        async function teardown() {
+            if (!client) { return }
+            client.removeAllListeners('error')
+            await client.ensureDisconnected()
+            client = undefined
+        }
+
+        beforeEach(async () => {
+            await teardown()
+        })
+
+        afterEach(async () => {
+            await teardown()
+        })
+
+        it('will connect if not connected if autoconnect set', async (done) => {
+            client = createClient({
+                autoConnect: true,
+                autoDisconnect: true,
+            })
+
+            client.once('error', done)
+
+            const stream = await client.createStream({
+                name: uniqueId(),
+            })
+            await client.ensureDisconnected()
+
+            const message = {
+                id2: uniqueId(),
+            }
+            client.once('connected', () => {
+                // wait in case of delayed errors
+                setTimeout(() => done(), 500)
+            })
+            await client.publish(stream.id, message)
+        })
+
+        it('will connect if disconnecting & autoconnect set', async (done) => {
+            client = createClient({
+                autoConnect: true,
+                autoDisconnect: true,
+            })
+
+            client.once('error', done)
+            await client.ensureConnected()
+            const stream = await client.createStream({
+                name: uniqueId(),
+            })
+
+            const message = {
+                id1: uniqueId(),
+            }
+            const p = client.publish(stream.id, message)
+            setTimeout(() => {
+                client.disconnect() // start async disconnect after publish started
+            })
+            await p
+            // wait in case of delayed errors
+            setTimeout(() => done(), 500)
+        })
+
+        it('will error if disconnecting & autoconnect not set', async (done) => {
+            client = createClient({
+                autoConnect: false,
+                autoDisconnect: false,
+            })
+
+            client.once('error', done)
+            await client.ensureConnected()
+            const stream = await client.createStream({
+                name: uniqueId(),
+            })
+
+            const message = {
+                id1: uniqueId(),
+            }
+
+            client.publish(stream.id, message).catch((err) => {
+                expect(err).toBeTruthy()
+                done()
+            })
+
+            setTimeout(() => {
+                client.disconnect() // start async disconnect after publish started
+            })
+        })
+    })
 })
 
 describe('StreamrClient', () => {
@@ -309,11 +399,6 @@ describe('StreamrClient', () => {
         return s
     }
 
-    const ensureConnected = () => new Promise((resolve) => {
-        client.on('connected', resolve)
-        client.connect()
-    })
-
     beforeEach(async () => {
         try {
             await Promise.all([
@@ -331,33 +416,44 @@ describe('StreamrClient', () => {
         }
 
         client = createClient()
-        await ensureConnected()
+        await client.ensureConnected()
         stream = await createStream()
     })
 
-    afterEach(() => {
-        if (client && client.isConnected()) {
-            return client.disconnect()
+    afterEach(async () => {
+        if (client) {
+            client.removeAllListeners('error')
+            await client.ensureDisconnected()
         }
-        return Promise.resolve()
     })
 
     describe('Pub/Sub', () => {
-        it('client.publish', () => client.publish(stream.id, {
-            test: 'client.publish',
-        }), TIMEOUT)
+        it('client.publish', async (done) => {
+            client.once('error', done)
+            await client.publish(stream.id, {
+                test: 'client.publish',
+            })
+            setTimeout(() => done(), TIMEOUT * 0.8)
+        }, TIMEOUT)
 
-        it('Stream.publish', () => stream.publish({
-            test: 'Stream.publish',
-        }), TIMEOUT)
+        it('Stream.publish', async (done) => {
+            client.once('error', done)
+            await stream.publish({
+                test: 'Stream.publish',
+            })
+            setTimeout(() => done(), TIMEOUT * 0.8)
+        }, TIMEOUT)
 
-        it('client.publish with Stream object as arg', () => {
-            client.publish(stream, {
+        it('client.publish with Stream object as arg', async (done) => {
+            client.once('error', done)
+            await client.publish(stream, {
                 test: 'client.publish.Stream.object',
             })
+            setTimeout(() => done(), TIMEOUT * 0.8)
         }, TIMEOUT)
 
         it('client.subscribe with resend from', (done) => {
+            client.once('error', done)
             // Publish message
             client.publish(stream.id, {
                 test: 'client.subscribe with resend',
@@ -400,6 +496,7 @@ describe('StreamrClient', () => {
         }, TIMEOUT)
 
         it('client.subscribe with resend last', (done) => {
+            client.once('error', done)
             // Publish message
             client.publish(stream.id, {
                 test: 'client.subscribe with resend',
@@ -440,6 +537,7 @@ describe('StreamrClient', () => {
         }, TIMEOUT)
 
         it('client.subscribe (realtime)', (done) => {
+            client.once('error', done)
             const id = Date.now()
             const sub = client.subscribe({
                 stream: stream.id,

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -73,7 +73,7 @@ describe('StreamrClient Connection', () => {
                 expect(onError).toHaveBeenCalledWith(error)
                 done()
             })
-        })
+        }, 10000)
     })
 
     describe('bad config.restUrl', () => {

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -806,6 +806,7 @@ describe('StreamrClient', () => {
         })
 
         it('rejects the promise if autoConnect is false and the client is not connected', (done) => {
+            client.options.auth.username = 'username'
             client.options.autoConnect = false
             client.publish('stream1', pubMsg).catch((err) => {
                 assert(err instanceof FailedToPublishError)


### PR DESCRIPTION
You may have noticed the following error being logged when running the integration tests:

> `Error: WebSocket is not open: readyState 2 (CLOSING)`

![image](https://user-images.githubusercontent.com/43438/56026606-13eef780-5d47-11e9-94c0-3728fdbaa502.png)

https://travis-ci.com/streamr-dev/streamr-client-javascript/jobs/191090350#L2869-L2884

The above gets logged during running the current integration tests, yet the test suite does not fail because no test is actually listening for the client 'error' event at the time it occurs. It seems to be caused by the test suite itself not waiting for the publish action to finish before disconnecting the client. It appears the message does fail to be published.

Note the code below from the current `master` branch:

https://github.com/streamr-dev/streamr-client-javascript/blob/39db82ddcdf7e0da8917b85768a359c338704965/src/StreamrClient.js#L269-L272

`createStreamMessage` is async, so it's entirely possible that the client will fully or partially disconnect between the first `isConnected` check and `createStreamMessage` resolving. This causes the `_requestPublish` to try writing to the disconnecting websocket, which in turn triggers the above error event, which isn't caught by anything.

This PR makes `publish` re-check the client is connected try to reconnect if `autoConnect` is set, or fail with an error "Disconnected before publish" otherwise. 

Also adjusted the tests that initially exhibited this error to `await` their operations before continuing.


----


**Update**: Noticed similar behaviour for subscriptions: if you call `client.disconnect()` on `subscribed`, and the subscription had resend options, the client will cough up a similar error event as it tries to write to a closing websocket: 

```
  console.error src/StreamrClient.js:229
    Error: WebSocket is not open: readyState 2 (CLOSING)
        at WebSocket.send (/Users/timoxley/Projects/streamr/streamr-client/node_modules/ws/lib/websocket.js:322:19)
        at Connection.send (/Users/timoxley/Projects/streamr/streamr-client/src/Connection.js:108:25)
        at send (/Users/timoxley/Projects/streamr/streamr-client/src/StreamrClient.js:559:29)
        at <anonymous>
        at process._tickCallback (internal/process/next_tick.js:189:7)
```

Solved this in 1fbd71167a44d60085e529ca43f8a7ef0312f891 by simply ignoring resend requests if the client is no longer connected. A more general solution should probably be found.