### PR TITLE
Add debug option. Replace console.error/warn with debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ verifySignatures | 'auto' | Determines under which conditions signed and unsigne
 autoConnect | true | If set to `true`, the client connects automatically on the first call to `subscribe()`. Otherwise an explicit call to `connect()` is required.
 autoDisconnect | true  | If set to `true`, the client automatically disconnects when the last stream is unsubscribed. Otherwise the connection is left open and can be disconnected explicitly by calling `disconnect()`.
 maxPublishQueueSize | 10000 | Only in effect when `autoConnect = true`. Controls the maximum number of messages to retain in internal queue when client has disconnected and is reconnecting to Streamr.
+debug | false | Enable debug logging
 
 ### Authentication options
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ verifySignatures | 'auto' | Determines under which conditions signed and unsigne
 autoConnect | true | If set to `true`, the client connects automatically on the first call to `subscribe()`. Otherwise an explicit call to `connect()` is required.
 autoDisconnect | true  | If set to `true`, the client automatically disconnects when the last stream is unsubscribed. Otherwise the connection is left open and can be disconnected explicitly by calling `disconnect()`.
 maxPublishQueueSize | 10000 | Only in effect when `autoConnect = true`. Controls the maximum number of messages to retain in internal queue when client has disconnected and is reconnecting to Streamr.
-debug | false | Enable debug logging
+debug | false | Enable debug logging. Uses [`debug`](https://github.com/visionmedia/debug) module. Can also be enabled via `DEBUG=StreamrClient*` environment variable.
 
 ### Authentication options
 
@@ -292,11 +292,3 @@ resending | [ResendResponseResending](https://github.com/streamr-dev/streamr-cli
 resent | [ResendResponseResent](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_resent/ResendResponseResentV1.js) | Fired after `resending` when the subscription has finished resending.
 no_resend | [ResendResponseNoResend](https://github.com/streamr-dev/streamr-client-protocol-js/blob/master/src/protocol/control_layer/resend_response_no_resend/ResendResponseNoResendV1.js) | This will occur instead of the `resending` - `resent` sequence in case there were no messages to resend.
 error | Error object | Reports errors, for example problems with message content
-
-### Logging
-
-The Streamr JS client library supports [debug](https://github.com/visionmedia/debug) for logging.
-
-In node.js, start your app like this: `DEBUG=StreamrClient* node your-app.js`
-
-In the browser, include `debug.js` and set `localStorage.debug = 'StreamrClient'`

--- a/src/MessageCreationUtil.js
+++ b/src/MessageCreationUtil.js
@@ -1,9 +1,12 @@
 import crypto from 'crypto'
 import NodeCache from 'node-cache'
 import randomstring from 'randomstring'
+import debugFactory from 'debug'
 import { MessageLayer } from 'streamr-client-protocol'
 import { ethers } from 'ethers'
 import Stream from './rest/domain/Stream'
+
+const debug = debugFactory('StreamrClient::MessageCreationUtil')
 
 const { StreamMessage } = MessageLayer
 
@@ -38,7 +41,7 @@ export default class MessageCreationUtil {
             }))
             const success = this.cachedStreams.set(streamId, streamPromise)
             if (!success) {
-                console.warn(`Could not store stream with id ${streamId} in local cache.`)
+                debug(`Could not store stream with id ${streamId} in local cache.`)
                 return streamPromise
             }
         }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -37,6 +37,7 @@ export default class StreamrClient extends EventEmitter {
 
         // Default options
         this.options = {
+            debug: false,
             // The server to connect to
             url: 'wss://www.streamr.com/api/v1/ws',
             restUrl: 'https://www.streamr.com/api/v1',
@@ -76,6 +77,10 @@ export default class StreamrClient extends EventEmitter {
             this.options.auth.apiKey = this.options.apiKey
         }
 
+        if (this.options.debug) {
+            debugFactory.enable(this.options.debug === true ? 'StreamrClient*' : this.options.debug)
+        }
+
         if (this.options.auth.privateKey && !this.options.auth.privateKey.startsWith('0x')) {
             this.options.auth.privateKey = `0x${this.options.auth.privateKey}`
         }
@@ -98,7 +103,7 @@ export default class StreamrClient extends EventEmitter {
         }
 
         this.on('error', (error) => {
-            console.error(error)
+            debug(error)
             this.ensureDisconnected()
         })
 
@@ -222,7 +227,7 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(ErrorResponse.TYPE, (err) => {
             const errorObject = new Error(err.errorMessage)
             this.emit('error', errorObject)
-            console.error(errorObject)
+            debug(errorObject)
         })
 
         this.connection.on('error', (err) => {
@@ -238,7 +243,7 @@ export default class StreamrClient extends EventEmitter {
                 // if it looks like an error emit as-is, otherwise wrap in new Error
                 const errorObject = (err && err.stack && err.message) ? err : new Error(err)
                 this.emit('error', errorObject)
-                console.error(errorObject)
+                debug(errorObject)
             }
         })
     }

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -87,7 +87,7 @@ class Subscription extends EventEmitter {
         try {
             return await fn()
         } catch (err) {
-            console.error(err)
+            debug(err)
             this.emit('error', err)
             // Swallow rejection
             return Promise.resolve()


### PR DESCRIPTION
Currently one cannot disable console messages in the client, whenever you get an error event, you will get an error logged to the console, regardless whether the error is handled or expected. 

This is a minor nuisance for consumers but also affects their tests: newer versions of Jest complain if console messages appear outside of test handlers. 

This PR allows opting into error logging via setting a `debug` flag in the client options.