### PR TITLE
Valid publishers optimization

### DIFF
--- a/src/Signer.js
+++ b/src/Signer.js
@@ -68,10 +68,9 @@ export default class Signer {
         throw new Error(`Unrecognized signature type: ${signatureType}`)
     }
 
-    static verifyStreamMessage(msg, trustedPublishers = new Set()) {
+    static verifyStreamMessage(msg) {
         const payload = this.getPayloadToSign(msg, msg.getPublisherId(), msg.signatureType)
         const result = this.verifySignature(payload, msg.signature, msg.getPublisherId(), msg.signatureType)
-            && trustedPublishers.has(msg.getPublisherId().toLowerCase())
         debug('verifyStreamMessage: pass: %o, message: %o', result, msg)
         return result
     }

--- a/src/SubscribedStream.js
+++ b/src/SubscribedStream.js
@@ -10,7 +10,7 @@ export default class SubscribedStream {
     }
 
     async getPublishers() {
-        if (!this.publishersPromise || (Date.now() - this.lastAccess) > PUBLISHERS_EXPIRATION_TIME) {
+        if (!this.publishersPromise || (Date.now() - this.lastUpdated) > PUBLISHERS_EXPIRATION_TIME) {
             this.publishersPromise = this._client.getStreamPublishers(this.streamId).then((publishers) => {
                 const map = {}
                 publishers.forEach((p) => {
@@ -18,12 +18,12 @@ export default class SubscribedStream {
                 })
                 return map
             })
-            this.lastAccess = Date.now()
+            this.lastUpdated = Date.now()
         }
         return this.publishersPromise
     }
 
-    async isPublisher(publisherId) {
+    async _isPublisher(publisherId) {
         if (!this.isPublisherPromises[publisherId]) {
             this.isPublisherPromises[publisherId] = this._client.isStreamPublisher(this.streamId, publisherId)
         }
@@ -35,7 +35,7 @@ export default class SubscribedStream {
         if (cache[publisherId]) {
             return cache[publisherId]
         }
-        const isValid = await this.isPublisher(publisherId)
+        const isValid = await this._isPublisher(publisherId)
         cache[publisherId] = isValid
         return isValid
     }

--- a/src/SubscribedStream.js
+++ b/src/SubscribedStream.js
@@ -6,21 +6,48 @@ export default class SubscribedStream {
         this._client = client
         this.streamId = streamId
         this.subscriptions = {}
+        this.isPublisherPromises = {}
     }
 
-    getPublishers() {
+    async getPublishers() {
         if (!this.publishersPromise || (Date.now() - this.lastAccess) > PUBLISHERS_EXPIRATION_TIME) {
-            this.publishersPromise = this._client.getStreamPublishers(this.streamId)
+            this.publishersPromise = this._client.getStreamPublishers(this.streamId).then((publishers) => {
+                const map = {}
+                publishers.forEach((p) => {
+                    map[p] = true
+                })
+                return map
+            })
             this.lastAccess = Date.now()
         }
         return this.publishersPromise
     }
 
+    async isPublisher(publisherId) {
+        if (!this.isPublisherPromises[publisherId]) {
+            this.isPublisherPromises[publisherId] = this._client.isStreamPublisher(this.streamId, publisherId)
+        }
+        return this.isPublisherPromises[publisherId]
+    }
+
+    async isValidPublisher(publisherId) {
+        const cache = await this.getPublishers()
+        if (cache[publisherId]) {
+            return cache[publisherId]
+        }
+        const isValid = await this.isPublisher(publisherId)
+        cache[publisherId] = isValid
+        return isValid
+    }
+
     async verifyStreamMessage(msg) {
         if (this._client.options.verifySignatures === 'always') {
             if (msg.signatureType && msg.signatureType !== 0 && msg.signature) {
-                const publishers = await this.getPublishers()
-                return Signer.verifyStreamMessage(msg, new Set(publishers))
+                const isValid = await this.isValidPublisher(msg.getPublisherId().toLowerCase())
+                if (!isValid) {
+                    return false
+                }
+                return Signer.verifyStreamMessage(msg)
             }
             return false
         } else if (this._client.options.verifySignatures === 'never') {
@@ -28,8 +55,11 @@ export default class SubscribedStream {
         }
         // if this._client.options.verifySignatures === 'auto'
         if (msg.signatureType && msg.signatureType !== 0 && msg.signature) { // always verify in case the message is signed
-            const publishers = await this.getPublishers()
-            return Signer.verifyStreamMessage(msg, new Set(publishers))
+            const isValid = await this.isValidPublisher(msg.getPublisherId().toLowerCase())
+            if (!isValid) {
+                return false
+            }
+            return Signer.verifyStreamMessage(msg)
         }
         return !(await this.getVerifySignatures())
     }

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -97,6 +97,19 @@ export async function getStreamPublishers(streamId) {
     return json.addresses.map((a) => a.toLowerCase())
 }
 
+export async function isStreamPublisher(streamId, ethAddress) {
+    const url = `${this.options.restUrl}/streams/${streamId}/publisher/${ethAddress}`
+    try {
+        await authFetch(url, this.session)
+        return true
+    } catch (e) {
+        if (e.response && e.response.status === 404) {
+            return false
+        }
+        throw e
+    }
+}
+
 export function publishHttp(streamObjectOrId, data, requestOptions = {}, keepAlive = true) {
     let streamId
     if (streamObjectOrId instanceof Stream) {

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -67,6 +67,16 @@ describe('StreamEndpoints', () => {
         assert.deepStrictEqual(publishers, [client.signer.address.toLowerCase()])
     })
 
+    it('client.isStreamPublisher should return true', async () => {
+        const valid = await client.isStreamPublisher(createdStream.id, client.signer.address.toLowerCase())
+        assert(valid)
+    })
+
+    it('client.isStreamPublisher should return false', async () => {
+        const valid = await client.isStreamPublisher(createdStream.id, 'some-wrong-address')
+        assert(!valid)
+    })
+
     describe('Stream.update', () => {
         it('can change stream name', () => {
             createdStream.name = 'New name'

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -651,7 +651,9 @@ describe('StreamrClient', () => {
                     const publishers = await subStream.getPublishers()
                     const requireVerification = await subStream.getVerifySignatures()
                     assert.strictEqual(requireVerification, true)
-                    assert.deepStrictEqual(publishers, [client.signer.address.toLowerCase()])
+                    const map = {}
+                    map[client.signer.address.toLowerCase()] = true
+                    assert.deepStrictEqual(publishers, map)
                     assert.strictEqual(streamMessage.signatureType, StreamMessage.SIGNATURE_TYPES.ETH)
                     assert(streamMessage.getPublisherId())
                     assert(streamMessage.signature)
@@ -692,7 +694,9 @@ describe('StreamrClient', () => {
                     const publishers = await subStream.getPublishers()
                     const requireVerification = await subStream.getVerifySignatures()
                     assert.strictEqual(requireVerification, true)
-                    assert.deepStrictEqual(publishers, [client.signer.address.toLowerCase()])
+                    const map = {}
+                    map[client.signer.address.toLowerCase()] = true
+                    assert.deepStrictEqual(publishers, map)
                     assert.strictEqual(streamMessage.signatureType, StreamMessage.SIGNATURE_TYPES.ETH)
                     assert(streamMessage.getPublisherId())
                     assert(streamMessage.signature)

--- a/test/unit/Signer.test.js
+++ b/test/unit/Signer.test.js
@@ -107,35 +107,28 @@ describe('Signer', () => {
                 [streamId, 0, timestamp, 0, signer.address, 'chain-id'], null, StreamMessage.CONTENT_TYPES.MESSAGE,
                 StreamMessage.ENCRYPTION_TYPES.NONE, data, StreamMessage.SIGNATURE_TYPES.ETH, correctSignatureV30AndV31,
             )
-            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage, new Set([signer.address.toLowerCase()])), true)
+            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage), true)
         })
         it('Should verify correct signature (V30)', () => {
             const signedStreamMessage = new StreamMessageV30(
                 [streamId, 0, timestamp, 0, signer.address, 'chain-id'], null, StreamMessage.CONTENT_TYPES.MESSAGE,
                 data, StreamMessage.SIGNATURE_TYPES.ETH, correctSignatureV30AndV31,
             )
-            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage, new Set([signer.address.toLowerCase()])), true)
+            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage), true)
         })
         it('Should verify correct signature (V29 but was converted to v30 for the client)', () => {
             const signedStreamMessage = (new StreamMessageV29(
                 streamId, 0, timestamp, 0, 0, 0, StreamMessage.CONTENT_TYPES.MESSAGE,
                 data, StreamMessage.SIGNATURE_TYPES.ETH_LEGACY, signer.address, correctSignatureV29,
             )).toOtherVersion(30)
-            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage, new Set([signer.address.toLowerCase()])), true)
+            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage), true)
         })
         it('Should return false if incorrect signature (V31)', () => {
             const wrongStreamMessage = new StreamMessageV31(
                 [streamId, 0, timestamp, 0, signer.address, ''], [timestamp - 10, 0], StreamMessage.CONTENT_TYPES.MESSAGE,
                 StreamMessage.ENCRYPTION_TYPES.NONE, data, StreamMessage.SIGNATURE_TYPES.ETH, wrongSignature,
             )
-            assert.strictEqual(Signer.verifyStreamMessage(wrongStreamMessage, new Set([signer.address.toLowerCase()])), false)
-        })
-        it('Should return false if correct signature but not from a trusted publisher', () => {
-            const signedStreamMessage = new StreamMessageV31(
-                [streamId, 0, timestamp, 0, signer.address, ''], [timestamp - 10, 0], StreamMessage.CONTENT_TYPES.MESSAGE,
-                StreamMessage.ENCRYPTION_TYPES.NONE, data, StreamMessage.SIGNATURE_TYPES.ETH, correctSignatureV30AndV31,
-            )
-            assert.strictEqual(Signer.verifyStreamMessage(signedStreamMessage, new Set()), false)
+            assert.strictEqual(Signer.verifyStreamMessage(wrongStreamMessage), false)
         })
     })
 })


### PR DESCRIPTION
The logic to check if an Ethereum address is a valid publisher is now the following:
- check cache (maps publisherId --> boolean)
- if hit, return cache result
- if miss, call the new endpoint `streams/id/publisher/address`, cache the result and return it