### PR TITLE
Add package.json note about babel-runtime vs devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "webpack-cli": "^3.3.5",
     "webpack-merge": "^4.2.1"
   },
+  "#IMPORTANT": "babel-runtime must be in dependencies, not devDependencies",
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
As requested in https://github.com/streamr-dev/streamr-client-javascript/pull/91#issuecomment-527823682