### PR TITLE
Fix problem with CombinedSubscription swapping out HistoricalSubscription for RealtimeSubscription and confusing the secondResend

### DIFF
--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -97,7 +97,7 @@ export default class AbstractSubscription extends Subscription {
             try {
                 this.emit('no_resend', response)
             } finally {
-                this._finishResend()
+                this._finishResend(true)
             }
         })
     }

--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -38,6 +38,7 @@ export default class CombinedSubscription extends Subscription {
         sub.on('resending', (response) => this.emit('resending', response))
         sub.on('resent', (response) => this.emit('resent', response))
         sub.on('no_resend', (response) => this.emit('no_resend', response))
+        sub.on('resend done', (response) => this.emit('resend done', response))
         sub.on('message received', () => this.emit('message received'))
         Object.keys(Subscription.State).forEach((state) => this.sub.on(state, () => this.emit(state)))
     }

--- a/src/HistoricalSubscription.js
+++ b/src/HistoricalSubscription.js
@@ -42,8 +42,14 @@ export default class HistoricalSubscription extends AbstractSubscription {
         return this.resendOptions
     }
 
-    _finishResend() {
-        this._lastMessageHandlerPromise = null
-        this.emit('resend done')
+    _finishResend(isNoResend = false) {
+        // if after a first resend request no messages are received (received ResendResponseNoResend),
+        // we wait for the response to the second resend request before considering the resend done (messages might have been stored in between)
+        if (isNoResend && !this.firstNoResendReceived) {
+            this.firstNoResendReceived = true
+        } else {
+            this._lastMessageHandlerPromise = null
+            this.emit('resend done')
+        }
     }
 }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -570,10 +570,12 @@ export default class StreamrClient extends EventEmitter {
                     // another resend if it doesn't. So we can anyway clear this resend request.
                     const handler = () => {
                         clearTimeout(secondResend)
+                        sub.removeListener('resend done', handler)
                         sub.removeListener('message received', handler)
                         sub.removeListener('unsubscribed', handler)
                         sub.removeListener('error', handler)
                     }
+                    sub.once('resend done', handler)
                     sub.once('message received', handler)
                     sub.once('unsubscribed', handler)
                     sub.once('error', handler)
@@ -630,8 +632,13 @@ export default class StreamrClient extends EventEmitter {
                 options.publisherId || null, options.msgChainId || null, sessionToken,
             )
         }
-        debug('_requestResend: %o', request)
-        this.connection.send(request)
+
+        if (request) {
+            debug('_requestResend: %o', request)
+            this.connection.send(request)
+        } else {
+            this.handleError("Can't _requestResend without resendOptions")
+        }
     }
 
     _requestPublish(streamMessage, sessionToken) {

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -137,7 +137,7 @@ describe('StreamrClient', () => {
         return c
     }
 
-    const STORAGE_DELAY = 500
+    const STORAGE_DELAY = 2000
 
     beforeEach(() => {
         clearAsync()
@@ -667,6 +667,22 @@ describe('StreamrClient', () => {
                     })
                     connection.expect(ResendLastRequest.create(sub.streamId, sub.streamPartition, sub.id, 5, 'session-token'))
                     connection.emitMessage(SubscribeResponse.create(sub.streamId))
+                    connection.expect(ResendLastRequest.create(sub.streamId, sub.streamPartition, sub.id, 5, 'session-token'))
+                    setTimeout(() => {
+                        sub.stop()
+                        done()
+                    }, STORAGE_DELAY + 200)
+                }, STORAGE_DELAY + 1000)
+
+                it('sends a second ResendLastRequests if no StreamMessage received and a ResendResponseNoResend received', (done) => {
+                    const sub = setupSubscription('stream1', false, {
+                        resend: {
+                            last: 5,
+                        },
+                    })
+                    connection.expect(ResendLastRequest.create(sub.streamId, sub.streamPartition, sub.id, 5, 'session-token'))
+                    connection.emitMessage(SubscribeResponse.create(sub.streamId))
+                    connection.emitMessage(ResendResponseNoResend.create(sub.streamId, sub.streamPartition, sub.id))
                     connection.expect(ResendLastRequest.create(sub.streamId, sub.streamPartition, sub.id, 5, 'session-token'))
                     setTimeout(() => {
                         sub.stop()


### PR DESCRIPTION
also some defense in case someone tries to requestResend RealtimeSubscriptions without resendOptions

no idea how to test that so didn't write a test... probably like: mock connection, emit "resend done" and see if it explodes. Timing is kind of important too though, to make secondResend still happen.

Also not sure if in fact one of the other handlers should catch it, or if they ever get activated. A flowchart or something might help seeing what can and shouldn't happen at each state.