### PR TITLE
Add failing realtime + resend test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ jobs:
     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 5"
     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh log -f &"
     - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/users/me); if [ $http_code = 401 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
-    - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/ws); if [ $http_code = 200 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
+    - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/ws); if [ $http_code = 426 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
     - npm run test-integration

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -84,7 +84,7 @@ export default class AbstractSubscription extends Subscription {
             try {
                 this.emit('resent', response)
             } finally {
-                this._finishResend()
+                this.finishResend()
             }
         })
     }
@@ -97,7 +97,7 @@ export default class AbstractSubscription extends Subscription {
             try {
                 this.emit('no_resend', response)
             } finally {
-                this._finishResend(true)
+                this.finishResend(true)
             }
         })
     }

--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -67,6 +67,10 @@ export default class CombinedSubscription extends Subscription {
         return this.sub.handleBroadcastMessage(msg, verifyFn)
     }
 
+    finishResend() {
+        return this.sub.finishResend()
+    }
+
     hasResendOptions() {
         return this.sub.hasResendOptions()
     }

--- a/src/HistoricalSubscription.js
+++ b/src/HistoricalSubscription.js
@@ -42,7 +42,7 @@ export default class HistoricalSubscription extends AbstractSubscription {
         return this.resendOptions
     }
 
-    _finishResend(isNoResend = false) {
+    finishResend(isNoResend = false) {
         // if after a first resend request no messages are received (received ResendResponseNoResend),
         // we wait for the response to the second resend request before considering the resend done (messages might have been stored in between)
         if (isNoResend && !this.firstNoResendReceived) {

--- a/src/RealTimeSubscription.js
+++ b/src/RealTimeSubscription.js
@@ -18,7 +18,7 @@ export default class RealTimeSubscription extends AbstractSubscription {
         return this._catchAndEmitErrors(() => this._handleMessage(msg, verifyFn))
     }
 
-    _finishResend() {
+    finishResend() {
         this._lastMessageHandlerPromise = null
         this.setResending(false)
     }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -577,6 +577,7 @@ export default class StreamrClient extends EventEmitter {
                         sub.removeListener('message received', handler)
                         sub.removeListener('unsubscribed', handler)
                         sub.removeListener('error', handler)
+                        sub.finishResend()
                     }
                     sub.once('resend done', handler)
                     sub.once('message received', handler)

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -744,6 +744,37 @@ describe('StreamrClient', () => {
             })
         })
 
+        it('client.subscribe (realtime with resend)', (done) => {
+            client.once('error', done)
+            const id = Date.now()
+            const sub = client.subscribe({
+                stream: stream.id,
+                resend: {
+                    last: 1,
+                },
+            }, (parsedContent, streamMessage) => {
+                assert.equal(parsedContent.id, id)
+
+                // Check signature stuff
+                assert.strictEqual(streamMessage.signatureType, StreamMessage.SIGNATURE_TYPES.ETH)
+                assert(streamMessage.getPublisherId())
+                assert(streamMessage.signature)
+
+                // All good, unsubscribe
+                client.unsubscribe(sub)
+                sub.on('unsubscribed', () => {
+                    done()
+                })
+            })
+
+            // Publish after subscribed
+            sub.on('subscribed', () => {
+                stream.publish({
+                    id,
+                })
+            })
+        }, 10000)
+
         it('client.subscribe can decrypt encrypted messages if it knows the group key', async (done) => {
             client.once('error', done)
             const id = Date.now()


### PR DESCRIPTION
I think this test captures at least one of the issues I was having with the client.

It seems resends work, and realtime works, but AFAICT they don't seem to work together.

Interestingly, this test passes when cherry-picked on top of `2.2.1`, so it's likely something to do with the [changes between `2.2.1` and `2.2.2`](https://github.com/streamr-dev/streamr-client-javascript/compare/e479b68927b8c6c5ce5d4fea8e8eb4309e55e9ec...7cb6790e2f53b984a2d8aa191ddda13f0df03b39#diff-b33004f77181ebaafb1f0c41f5c34f07R45-R53), likely this commit: 36058631d48fe702eb3e1cd4738fd5f06fe88e4b