### PR TITLE
Identify subscriptions by streamId+partition, not by streamId

### DIFF
--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -28,7 +28,7 @@ import HistoricalSubscription from './HistoricalSubscription'
 import Connection from './Connection'
 import Session from './Session'
 import Signer from './Signer'
-import SubscribedStream from './SubscribedStreamPartition'
+import SubscribedStreamPartition from './SubscribedStreamPartition'
 import Stream from './rest/domain/Stream'
 import FailedToPublishError from './errors/FailedToPublishError'
 import MessageCreationUtil from './MessageCreationUtil'
@@ -283,7 +283,7 @@ export default class StreamrClient extends EventEmitter {
     _addSubscription(sub) {
         let sp = this._getSubscribedStreamPartition(sub.streamId, sub.streamPartition)
         if (!sp) {
-            sp = new SubscribedStream(this, sub.streamId, sub.streamPartition)
+            sp = new SubscribedStreamPartition(this, sub.streamId, sub.streamPartition)
             this._addSubscribedStreamPartition(sp)
         }
         sp.addSubscription(sub)

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -28,7 +28,7 @@ import HistoricalSubscription from './HistoricalSubscription'
 import Connection from './Connection'
 import Session from './Session'
 import Signer from './Signer'
-import SubscribedStream from './SubscribedStream'
+import SubscribedStream from './SubscribedStreamPartition'
 import Stream from './rest/domain/Stream'
 import FailedToPublishError from './errors/FailedToPublishError'
 import MessageCreationUtil from './MessageCreationUtil'
@@ -63,7 +63,7 @@ export default class StreamrClient extends EventEmitter {
             streamrOperatorAddress: '0xc0aa4dC0763550161a6B59fa430361b5a26df28C',
             tokenAddress: '0x0Cf0Ee63788A0849fE5297F3407f701E122cC023',
         }
-        this.subscribedStreams = {}
+        this.subscribedStreamPartitions = {}
 
         Object.assign(this.options, options || {})
 
@@ -118,9 +118,9 @@ export default class StreamrClient extends EventEmitter {
             this.ensureDisconnected()
         })
 
-        // Broadcast messages to all subs listening on stream
+        // Broadcast messages to all subs listening on stream-partition
         this.connection.on(BroadcastMessage.TYPE, (msg) => {
-            const stream = this.subscribedStreams[msg.streamMessage.getStreamId()]
+            const stream = this._getSubscribedStreamPartition(msg.streamMessage.getStreamId(), msg.streamMessage.getStreamPartition())
             if (stream) {
                 const verifyFn = once(() => stream.verifyStreamMessage(msg.streamMessage)) // ensure verification occurs only once
                 // sub.handleBroadcastMessage never rejects: on any error it emits an 'error' event on the Subscription
@@ -132,7 +132,7 @@ export default class StreamrClient extends EventEmitter {
 
         // Unicast messages to a specific subscription only
         this.connection.on(UnicastMessage.TYPE, async (msg) => {
-            const stream = this.subscribedStreams[msg.streamMessage.getStreamId()]
+            const stream = this._getSubscribedStreamPartition(msg.streamMessage.getStreamId(), msg.streamMessage.getStreamPartition())
             if (stream) {
                 const sub = stream.getSubscription(msg.subId)
                 if (sub) {
@@ -150,7 +150,7 @@ export default class StreamrClient extends EventEmitter {
         })
 
         this.connection.on(SubscribeResponse.TYPE, (response) => {
-            const stream = this.subscribedStreams[response.streamId]
+            const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             if (stream) {
                 stream.setSubscribing(false)
                 stream.getSubscriptions().filter((sub) => !sub.resending)
@@ -161,7 +161,7 @@ export default class StreamrClient extends EventEmitter {
 
         this.connection.on(UnsubscribeResponse.TYPE, (response) => {
             debug('Client unsubscribed: streamId: %s, streamPartition: %s', response.streamId, response.streamPartition)
-            const stream = this.subscribedStreams[response.streamId]
+            const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             if (stream) {
                 stream.getSubscriptions().forEach((sub) => {
                     this._removeSubscription(sub)
@@ -174,7 +174,7 @@ export default class StreamrClient extends EventEmitter {
 
         // Route resending state messages to corresponding Subscriptions
         this.connection.on(ResendResponseResending.TYPE, (response) => {
-            const stream = this.subscribedStreams[response.streamId]
+            const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             if (stream && stream.getSubscription(response.subId)) {
                 stream.getSubscription(response.subId).handleResending(response)
             } else {
@@ -183,7 +183,7 @@ export default class StreamrClient extends EventEmitter {
         })
 
         this.connection.on(ResendResponseNoResend.TYPE, (response) => {
-            const stream = this.subscribedStreams[response.streamId]
+            const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             if (stream && stream.getSubscription(response.subId)) {
                 stream.getSubscription(response.subId).handleNoResend(response)
             } else {
@@ -192,7 +192,7 @@ export default class StreamrClient extends EventEmitter {
         })
 
         this.connection.on(ResendResponseResent.TYPE, (response) => {
-            const stream = this.subscribedStreams[response.streamId]
+            const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             if (stream && stream.getSubscription(response.subId)) {
                 stream.getSubscription(response.subId).handleResent(response)
             } else {
@@ -206,9 +206,9 @@ export default class StreamrClient extends EventEmitter {
             this.emit('connected')
 
             // Check pending subscriptions
-            Object.keys(this.subscribedStreams)
-                .forEach((streamId) => {
-                    this.subscribedStreams[streamId].getSubscriptions().forEach((sub) => {
+            Object.keys(this.subscribedStreamPartitions)
+                .forEach((key) => {
+                    this.subscribedStreamPartitions[key].getSubscriptions().forEach((sub) => {
                         if (sub.getState() !== Subscription.State.subscribed) {
                             this._resendAndSubscribe(sub)
                         }
@@ -225,9 +225,9 @@ export default class StreamrClient extends EventEmitter {
             debug('Disconnected.')
             this.emit('disconnected')
 
-            Object.keys(this.subscribedStreams)
-                .forEach((streamId) => {
-                    const stream = this.subscribedStreams[streamId]
+            Object.keys(this.subscribedStreamPartitions)
+                .forEach((key) => {
+                    const stream = this.subscribedStreamPartitions[key]
                     stream.setSubscribing(false)
                     stream.getSubscriptions().forEach((sub) => {
                         sub.setState(Subscription.State.unsubscribed)
@@ -244,7 +244,7 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on('error', (err) => {
             // If there is an error parsing a json message in a stream, fire error events on the relevant subs
             if (err instanceof Errors.InvalidJsonError) {
-                const stream = this.subscribedStreams[err.streamId]
+                const stream = this._getSubscribedStreamPartition(err.streamMessage.getStreamId(), err.streamMessage.getStreamPartition())
                 if (stream) {
                     stream.getSubscriptions().forEach((sub) => sub.handleError(err))
                 } else {
@@ -259,26 +259,60 @@ export default class StreamrClient extends EventEmitter {
         })
     }
 
+    _getSubscribedStreamPartition(streamId, streamPartition) {
+        const key = streamId + streamPartition
+        return this.subscribedStreamPartitions[key]
+    }
+
+    _getSubscribedStreamPartitionsForStream(streamId) {
+        // TODO: pretty crude method, could improve
+        return Object.values(this.subscribedStreamPartitions)
+            .filter((stream) => stream.streamId === streamId)
+    }
+
+    _addSubscribedStreamPartition(subscribedStreamPartition) {
+        const key = subscribedStreamPartition.streamId + subscribedStreamPartition.streamPartition
+        this.subscribedStreamPartitions[key] = subscribedStreamPartition
+    }
+
+    _deleteSubscribedStreamPartition(subscribedStreamPartition) {
+        const key = subscribedStreamPartition.streamId + subscribedStreamPartition.streamPartition
+        delete this.subscribedStreamPartitions[key]
+    }
+
     _addSubscription(sub) {
-        if (!this.subscribedStreams[sub.streamId]) {
-            this.subscribedStreams[sub.streamId] = new SubscribedStream(this, sub.streamId)
+        let sp = this._getSubscribedStreamPartition(sub.streamId, sub.streamPartition)
+        if (!sp) {
+            sp = new SubscribedStream(this, sub.streamId, sub.streamPartition)
+            this._addSubscribedStreamPartition(sp)
         }
-        this.subscribedStreams[sub.streamId].addSubscription(sub)
+        sp.addSubscription(sub)
     }
 
     _removeSubscription(sub) {
-        const stream = this.subscribedStreams[sub.streamId]
-        if (stream) {
-            stream.removeSubscription(sub)
-            if (stream.getSubscriptions().length === 0) {
-                delete this.subscribedStreams[sub.streamId]
+        const sp = this._getSubscribedStreamPartition(sub.streamId, sub.streamPartition)
+        if (sp) {
+            sp.removeSubscription(sub)
+            if (sp.getSubscriptions().length === 0) {
+                this._deleteSubscribedStreamPartition(sp)
             }
         }
     }
 
-    getSubscriptions(streamId) {
-        const stream = this.subscribedStreams[streamId]
-        return stream ? stream.getSubscriptions() : []
+    getSubscriptions(streamId, streamPartition) {
+        let subs = []
+
+        if (streamPartition) {
+            const sp = this._getSubscribedStreamPartition(streamId, streamPartition)
+            if (sp) {
+                subs = sp.getSubscriptions()
+            }
+        } else {
+            const sps = this._getSubscribedStreamPartitionsForStream(streamId)
+            sps.forEach((sp) => sp.getSubscriptions().forEach((sub) => subs.push(sub)))
+        }
+
+        return subs
     }
 
     async publish(streamObjectOrId, data, timestamp = new Date(), partitionKey = null, groupKey) {
@@ -437,12 +471,14 @@ export default class StreamrClient extends EventEmitter {
             throw new Error('unsubscribe: please give a Subscription object as an argument!')
         }
 
-        // If this is the last subscription for this stream, unsubscribe the client too
-        if (this.subscribedStreams[sub.streamId] !== undefined && this.subscribedStreams[sub.streamId].getSubscriptions().length === 1
+        const sp = this._getSubscribedStreamPartition(sub.streamId, sub.streamPartition)
+
+        // If this is the last subscription for this stream-partition, unsubscribe the client too
+        if (sp && sp.getSubscriptions().length === 1
             && this.isConnected()
             && sub.getState() === Subscription.State.subscribed) {
             sub.setState(Subscription.State.unsubscribing)
-            this._requestUnsubscribe(sub.streamId)
+            this._requestUnsubscribe(sub)
         } else if (sub.getState() !== Subscription.State.unsubscribing && sub.getState() !== Subscription.State.unsubscribed) {
             // Else the sub can be cleaned off immediately
             this._removeSubscription(sub)
@@ -451,19 +487,30 @@ export default class StreamrClient extends EventEmitter {
         }
     }
 
-    unsubscribeAll(streamId) {
+    unsubscribeAll(streamId, streamPartition) {
         if (!streamId) {
             throw new Error('unsubscribeAll: a stream id is required!')
         } else if (typeof streamId !== 'string') {
             throw new Error('unsubscribe: stream id must be a string!')
         }
 
-        const stream = this.subscribedStreams[streamId]
-        if (stream) {
-            stream.getSubscriptions().forEach((sub) => {
+        let streamPartitions = []
+
+        // Unsubscribe all subs for the given stream-partition
+        if (streamPartition) {
+            const sp = this._getSubscribedStreamPartition(streamId, streamPartition)
+            if (sp) {
+                streamPartitions = [sp]
+            }
+        } else {
+            streamPartitions = this._getSubscribedStreamPartitionsForStream(streamId)
+        }
+
+        streamPartitions.forEach((sp) => {
+            sp.getSubscriptions().forEach((sub) => {
                 this.unsubscribe(sub)
             })
-        }
+        })
     }
 
     isConnected() {
@@ -508,7 +555,7 @@ export default class StreamrClient extends EventEmitter {
             this.msgCreationUtil.stop()
         }
 
-        this.subscribedStreams = {}
+        this.subscribedStreamPartitions = {}
         return this.connection.disconnect()
     }
 
@@ -552,7 +599,7 @@ export default class StreamrClient extends EventEmitter {
 
     _checkAutoDisconnect() {
         // Disconnect if no longer subscribed to any streams
-        if (this.options.autoDisconnect && Object.keys(this.subscribedStreams).length === 0) {
+        if (this.options.autoDisconnect && Object.keys(this.subscribedStreamPartitions).length === 0) {
             debug('Disconnecting due to no longer being subscribed to any streams')
             this.disconnect()
         }
@@ -588,31 +635,31 @@ export default class StreamrClient extends EventEmitter {
         }
     }
 
-    _requestSubscribe(sub) {
-        const stream = this.subscribedStreams[sub.streamId]
-        const subscribedSubs = stream.getSubscriptions().filter((it) => it.getState() === Subscription.State.subscribed)
+    async _requestSubscribe(sub) {
+        const sp = this._getSubscribedStreamPartition(sub.streamId, sub.streamPartition)
+        const subscribedSubs = sp.getSubscriptions().filter((it) => it.getState() === Subscription.State.subscribed)
 
-        return this.session.getSessionToken().then((sessionToken) => {
-            // If this is the first subscription for this stream, send a subscription request to the server
-            if (!stream.isSubscribing() && subscribedSubs.length === 0) {
-                const request = SubscribeRequest.create(sub.streamId, sub.streamPartition, sessionToken)
-                debug('_requestSubscribe: subscribing client: %o', request)
-                stream.setSubscribing(true)
-                this.connection.send(request)
-            } else if (subscribedSubs.length > 0) {
-                // If there already is a subscribed subscription for this stream, this new one will just join it immediately
-                debug('_requestSubscribe: another subscription for same stream: %s, insta-subscribing', sub.streamId)
+        const sessionToken = await this.session.getSessionToken()
 
-                setTimeout(() => {
-                    sub.setState(Subscription.State.subscribed)
-                })
-            }
-        })
+        // If this is the first subscription for this stream-partition, send a subscription request to the server
+        if (!sp.isSubscribing() && subscribedSubs.length === 0) {
+            const request = SubscribeRequest.create(sub.streamId, sub.streamPartition, sessionToken)
+            debug('_requestSubscribe: subscribing client: %o', request)
+            sp.setSubscribing(true)
+            this.connection.send(request)
+        } else if (subscribedSubs.length > 0) {
+            // If there already is a subscribed subscription for this stream, this new one will just join it immediately
+            debug('_requestSubscribe: another subscription for same stream: %s, insta-subscribing', sub.streamId)
+
+            setTimeout(() => {
+                sub.setState(Subscription.State.subscribed)
+            })
+        }
     }
 
-    _requestUnsubscribe(streamId) {
-        debug('Client unsubscribing stream %o', streamId)
-        this.connection.send(UnsubscribeRequest.create(streamId))
+    _requestUnsubscribe(sub) {
+        debug('Client unsubscribing stream %o partition %o', sub.streamId, sub.streamPartition)
+        this.connection.send(UnsubscribeRequest.create(sub.streamId, sub.streamPartition))
     }
 
     async _requestResend(sub, resendOptions) {

--- a/src/SubscribedStreamPartition.js
+++ b/src/SubscribedStreamPartition.js
@@ -2,13 +2,14 @@ import debugFactory from 'debug'
 
 import Signer from './Signer'
 
-const debug = debugFactory('StreamrClient::SubscribedStream')
+const debug = debugFactory('StreamrClient::SubscribedStreamPartition')
 
 const PUBLISHERS_EXPIRATION_TIME = 30 * 60 * 1000 // 30 minutes
-export default class SubscribedStream {
-    constructor(client, streamId) {
+export default class SubscribedStreamPartition {
+    constructor(client, streamId, streamPartition) {
         this._client = client
         this.streamId = streamId
+        this.streamPartition = streamPartition
         this.subscriptions = {}
         this.isPublisherPromises = {}
     }
@@ -122,4 +123,4 @@ export default class SubscribedStream {
         }
     }
 }
-SubscribedStream.PUBLISHERS_EXPIRATION_TIME = PUBLISHERS_EXPIRATION_TIME
+SubscribedStreamPartition.PUBLISHERS_EXPIRATION_TIME = PUBLISHERS_EXPIRATION_TIME

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -636,7 +636,7 @@ describe('StreamrClient', () => {
             })
 
             // Check that we're not subscribed yet
-            assert.strictEqual(client.subscribedStreams[stream.id], undefined)
+            assert.strictEqual(client.getSubscriptions()[stream.id], undefined)
 
             // Add delay: this test needs some time to allow the message to be written to Cassandra
             setTimeout(() => {
@@ -652,7 +652,8 @@ describe('StreamrClient', () => {
                     assert.strictEqual(parsedContent.test, 'client.subscribe with resend')
 
                     // Check signature stuff
-                    const subStream = client.subscribedStreams[stream.id]
+                    // WARNING: digging into internals
+                    const subStream = client._getSubscribedStreamPartition(stream.id, 0) // eslint-disable-line no-underscore-dangle
                     const publishers = await subStream.getPublishers()
                     const requireVerification = await subStream.getVerifySignatures()
                     assert.strictEqual(requireVerification, true)
@@ -666,7 +667,7 @@ describe('StreamrClient', () => {
                     // All good, unsubscribe
                     client.unsubscribe(sub)
                     sub.on('unsubscribed', () => {
-                        assert.strictEqual(client.subscribedStreams[stream.id], undefined)
+                        assert.strictEqual(client.getSubscriptions(stream.id).length, 0)
                         done()
                     })
                 })
@@ -681,7 +682,7 @@ describe('StreamrClient', () => {
             })
 
             // Check that we're not subscribed yet
-            assert.strictEqual(client.subscribedStreams[stream.id], undefined)
+            assert.strictEqual(client.getSubscriptions(stream.id).length, 0)
 
             // Add delay: this test needs some time to allow the message to be written to Cassandra
             setTimeout(() => {
@@ -695,7 +696,8 @@ describe('StreamrClient', () => {
                     assert.strictEqual(parsedContent.test, 'client.subscribe with resend')
 
                     // Check signature stuff
-                    const subStream = client.subscribedStreams[stream.id]
+                    // WARNING: digging into internals
+                    const subStream = client._getSubscribedStreamPartition(stream.id, 0) // eslint-disable-line no-underscore-dangle
                     const publishers = await subStream.getPublishers()
                     const requireVerification = await subStream.getVerifySignatures()
                     assert.strictEqual(requireVerification, true)
@@ -709,7 +711,7 @@ describe('StreamrClient', () => {
                     // All good, unsubscribe
                     client.unsubscribe(sub)
                     sub.on('unsubscribed', () => {
-                        assert.strictEqual(client.subscribedStreams[stream.id], undefined)
+                        assert.strictEqual(client.getSubscriptions(stream.id).length, 0)
                         done()
                     })
                 })

--- a/test/unit/SubscribedStreamPartition.test.js
+++ b/test/unit/SubscribedStreamPartition.test.js
@@ -3,13 +3,13 @@ import assert from 'assert'
 import sinon from 'sinon'
 import { MessageLayer } from 'streamr-client-protocol'
 
-import SubscribedStream from '../../src/SubscribedStream'
+import SubscribedStreamPartition from '../../src/SubscribedStreamPartition'
 import Signer from '../../src/Signer'
 import RealTimeSubscription from '../../src/RealTimeSubscription'
 
 const { StreamMessage } = MessageLayer
 
-describe('SubscribedStream', () => {
+describe('SubscribedStreamPartition', () => {
     let subscribedStream
     const publishers = ['0xb8ce9ab6943e0eced004cde8e3bbed6568b2fa01'.toLowerCase(), 'publisher2', 'publisher3']
     const publishersMap = {}
@@ -45,7 +45,7 @@ describe('SubscribedStream', () => {
             let stream
             beforeEach(() => {
                 ({ client, stream } = setupClientAndStream())
-                subscribedStream = new SubscribedStream(client, 'streamId')
+                subscribedStream = new SubscribedStreamPartition(client, 'streamId')
             })
             describe('getPublishers', () => {
                 it('should use endpoint to retrieve publishers', async () => {
@@ -73,7 +73,7 @@ describe('SubscribedStream', () => {
                     await subscribedStream.getPublishers()
                     subscribedStream.publishersPromise = Promise.resolve(publishersMap)
                     await subscribedStream.getPublishers()
-                    clock.tick(SubscribedStream.PUBLISHERS_EXPIRATION_TIME + 100)
+                    clock.tick(SubscribedStreamPartition.PUBLISHERS_EXPIRATION_TIME + 100)
                     await subscribedStream.getPublishers()
                     assert(client.getStreamPublishers.calledTwice)
                     clock.restore()
@@ -137,7 +137,7 @@ describe('SubscribedStream', () => {
                 )
                 await signer.signStreamMessage(msg)
                 const spiedVerifyStreamMessage = sinon.spy(Signer, 'verifyStreamMessage')
-                subscribedStream = new SubscribedStream(setupClientAndStream('auto', true).client, 'streamId')
+                subscribedStream = new SubscribedStreamPartition(setupClientAndStream('auto', true).client, 'streamId')
                 const valid = await subscribedStream.verifyStreamMessage(msg)
                 assert.strictEqual(valid, false)
                 assert(spiedVerifyStreamMessage.notCalled)
@@ -166,7 +166,7 @@ describe('SubscribedStream', () => {
                 spiedVerifyStreamMessage = sinon.spy(Signer, 'verifyStreamMessage')
             })
             afterEach(async () => {
-                subscribedStream = new SubscribedStream(client, 'streamId')
+                subscribedStream = new SubscribedStreamPartition(client, 'streamId')
                 const valid = await subscribedStream.verifyStreamMessage(msg)
                 assert.strictEqual(valid, true)
                 assert(spiedExpectedCall())
@@ -205,7 +205,7 @@ describe('SubscribedStream', () => {
                 )
             })
             afterEach(async () => {
-                subscribedStream = new SubscribedStream(client, 'streamId')
+                subscribedStream = new SubscribedStreamPartition(client, 'streamId')
                 const valid = await subscribedStream.verifyStreamMessage(msg)
                 assert.strictEqual(valid, expectedValid)
             })
@@ -232,7 +232,7 @@ describe('SubscribedStream', () => {
         let sub1
         beforeEach(() => {
             ({ client } = setupClientAndStream())
-            subscribedStream = new SubscribedStream(client, 'streamId')
+            subscribedStream = new SubscribedStreamPartition(client, 'streamId')
             sub1 = new RealTimeSubscription('sub1Id', 0, () => {})
         })
         it('should add and remove subscription correctly', () => {

--- a/test/unit/SubscribedStreamPartition.test.js
+++ b/test/unit/SubscribedStreamPartition.test.js
@@ -10,7 +10,7 @@ import RealTimeSubscription from '../../src/RealTimeSubscription'
 const { StreamMessage } = MessageLayer
 
 describe('SubscribedStreamPartition', () => {
-    let subscribedStream
+    let subscribedStreamPartition
     const publishers = ['0xb8ce9ab6943e0eced004cde8e3bbed6568b2fa01'.toLowerCase(), 'publisher2', 'publisher3']
     const publishersMap = {}
     publishers.forEach((p) => {
@@ -45,24 +45,24 @@ describe('SubscribedStreamPartition', () => {
             let stream
             beforeEach(() => {
                 ({ client, stream } = setupClientAndStream())
-                subscribedStream = new SubscribedStreamPartition(client, 'streamId')
+                subscribedStreamPartition = new SubscribedStreamPartition(client, 'streamId')
             })
             describe('getPublishers', () => {
                 it('should use endpoint to retrieve publishers', async () => {
-                    const retrievedPublishers = await subscribedStream.getPublishers()
+                    const retrievedPublishers = await subscribedStreamPartition.getPublishers()
                     assert(client.getStreamPublishers.calledOnce)
                     assert.deepStrictEqual(publishersMap, retrievedPublishers)
-                    assert.deepStrictEqual(await subscribedStream.publishersPromise, publishersMap)
+                    assert.deepStrictEqual(await subscribedStreamPartition.publishersPromise, publishersMap)
                 })
                 it('should use stored publishers and not the endpoint', async () => {
-                    subscribedStream.publishersPromise = Promise.resolve(publishersMap)
-                    const retrievedPublishers = await subscribedStream.getPublishers()
+                    subscribedStreamPartition.publishersPromise = Promise.resolve(publishersMap)
+                    const retrievedPublishers = await subscribedStreamPartition.getPublishers()
                     assert(client.getStreamPublishers.notCalled)
                     assert.deepStrictEqual(publishersMap, retrievedPublishers)
                 })
                 it('should call getStreamPublishers only once when multiple calls made simultaneously', () => {
-                    const p1 = subscribedStream.getPublishers()
-                    const p2 = subscribedStream.getPublishers()
+                    const p1 = subscribedStreamPartition.getPublishers()
+                    const p2 = subscribedStreamPartition.getPublishers()
                     return Promise.all([p1, p2]).then(([publishers1, publishers2]) => {
                         assert(client.getStreamPublishers.calledOnce)
                         assert.deepStrictEqual(publishers1, publishers2)
@@ -70,50 +70,50 @@ describe('SubscribedStreamPartition', () => {
                 })
                 it('should use endpoint again after the list of locally stored publishers expires', async () => {
                     const clock = sinon.useFakeTimers()
-                    await subscribedStream.getPublishers()
-                    subscribedStream.publishersPromise = Promise.resolve(publishersMap)
-                    await subscribedStream.getPublishers()
+                    await subscribedStreamPartition.getPublishers()
+                    subscribedStreamPartition.publishersPromise = Promise.resolve(publishersMap)
+                    await subscribedStreamPartition.getPublishers()
                     clock.tick(SubscribedStreamPartition.PUBLISHERS_EXPIRATION_TIME + 100)
-                    await subscribedStream.getPublishers()
+                    await subscribedStreamPartition.getPublishers()
                     assert(client.getStreamPublishers.calledTwice)
                     clock.restore()
                 })
             })
             describe('isValidPublisher', () => {
                 it('should return cache result if cache hit', async () => {
-                    const valid = await subscribedStream.isValidPublisher('publisher2')
+                    const valid = await subscribedStreamPartition.isValidPublisher('publisher2')
                     assert.strictEqual(valid, true)
                     assert(client.getStreamPublishers.calledOnce)
                     assert(client.isStreamPublisher.notCalled)
                 })
                 it('should fetch if cache miss and store result in cache', async () => {
-                    const valid4 = await subscribedStream.isValidPublisher('publisher4')
+                    const valid4 = await subscribedStreamPartition.isValidPublisher('publisher4')
                     assert.strictEqual(valid4, true)
-                    const valid5 = await subscribedStream.isValidPublisher('publisher5')
+                    const valid5 = await subscribedStreamPartition.isValidPublisher('publisher5')
                     assert.strictEqual(valid5, false)
                     // calling the function again should use the cache
-                    await subscribedStream.isValidPublisher('publisher4')
-                    await subscribedStream.isValidPublisher('publisher5')
+                    await subscribedStreamPartition.isValidPublisher('publisher4')
+                    await subscribedStreamPartition.isValidPublisher('publisher5')
                     assert(client.getStreamPublishers.calledOnce)
                     assert(client.isStreamPublisher.calledTwice)
                 })
             })
             describe('getStream', () => {
                 it('should use endpoint to retrieve stream', async () => {
-                    const retrievedStream = await subscribedStream.getStream()
+                    const retrievedStream = await subscribedStreamPartition.getStream()
                     assert(client.getStream.calledOnce)
                     assert.strictEqual(stream, retrievedStream)
-                    assert.strictEqual(stream, await subscribedStream.streamPromise)
+                    assert.strictEqual(stream, await subscribedStreamPartition.streamPromise)
                 })
                 it('should use stored stream and not the endpoint', async () => {
-                    subscribedStream.streamPromise = Promise.resolve(stream)
-                    const retrievedStream = await subscribedStream.getStream()
+                    subscribedStreamPartition.streamPromise = Promise.resolve(stream)
+                    const retrievedStream = await subscribedStreamPartition.getStream()
                     assert(client.getStream.notCalled)
                     assert.strictEqual(stream, retrievedStream)
                 })
                 it('should call the endpoint only once when multiple calls made simultaneously', () => {
-                    const p1 = subscribedStream.getStream()
-                    const p2 = subscribedStream.getStream()
+                    const p1 = subscribedStreamPartition.getStream()
+                    const p2 = subscribedStreamPartition.getStream()
                     return Promise.all([p1, p2]).then(([stream1, stream2]) => {
                         assert(client.getStream.calledOnce)
                         assert.deepStrictEqual(stream1, stream2)
@@ -137,8 +137,8 @@ describe('SubscribedStreamPartition', () => {
                 )
                 await signer.signStreamMessage(msg)
                 const spiedVerifyStreamMessage = sinon.spy(Signer, 'verifyStreamMessage')
-                subscribedStream = new SubscribedStreamPartition(setupClientAndStream('auto', true).client, 'streamId')
-                const valid = await subscribedStream.verifyStreamMessage(msg)
+                subscribedStreamPartition = new SubscribedStreamPartition(setupClientAndStream('auto', true).client, 'streamId')
+                const valid = await subscribedStreamPartition.verifyStreamMessage(msg)
                 assert.strictEqual(valid, false)
                 assert(spiedVerifyStreamMessage.notCalled)
                 spiedVerifyStreamMessage.restore()
@@ -166,8 +166,8 @@ describe('SubscribedStreamPartition', () => {
                 spiedVerifyStreamMessage = sinon.spy(Signer, 'verifyStreamMessage')
             })
             afterEach(async () => {
-                subscribedStream = new SubscribedStreamPartition(client, 'streamId')
-                const valid = await subscribedStream.verifyStreamMessage(msg)
+                subscribedStreamPartition = new SubscribedStreamPartition(client, 'streamId')
+                const valid = await subscribedStreamPartition.verifyStreamMessage(msg)
                 assert.strictEqual(valid, true)
                 assert(spiedExpectedCall())
                 spiedVerifyStreamMessage.restore()
@@ -205,8 +205,8 @@ describe('SubscribedStreamPartition', () => {
                 )
             })
             afterEach(async () => {
-                subscribedStream = new SubscribedStreamPartition(client, 'streamId')
-                const valid = await subscribedStream.verifyStreamMessage(msg)
+                subscribedStreamPartition = new SubscribedStreamPartition(client, 'streamId')
+                const valid = await subscribedStreamPartition.verifyStreamMessage(msg)
                 assert.strictEqual(valid, expectedValid)
             })
             it('should return false when "auto" verification and stream requires signed data', () => {
@@ -232,26 +232,26 @@ describe('SubscribedStreamPartition', () => {
         let sub1
         beforeEach(() => {
             ({ client } = setupClientAndStream())
-            subscribedStream = new SubscribedStreamPartition(client, 'streamId')
+            subscribedStreamPartition = new SubscribedStreamPartition(client, 'streamId')
             sub1 = new RealTimeSubscription('sub1Id', 0, () => {})
         })
         it('should add and remove subscription correctly', () => {
-            assert(subscribedStream.getSubscription(sub1.id) === undefined)
-            subscribedStream.addSubscription(sub1)
-            assert(subscribedStream.getSubscription(sub1.id) === sub1)
-            subscribedStream.removeSubscription(sub1)
-            assert(subscribedStream.getSubscription(sub1.id) === undefined)
+            assert(subscribedStreamPartition.getSubscription(sub1.id) === undefined)
+            subscribedStreamPartition.addSubscription(sub1)
+            assert(subscribedStreamPartition.getSubscription(sub1.id) === sub1)
+            subscribedStreamPartition.removeSubscription(sub1)
+            assert(subscribedStreamPartition.getSubscription(sub1.id) === undefined)
         })
         it('should get subscriptions array', () => {
-            subscribedStream.addSubscription(sub1)
+            subscribedStreamPartition.addSubscription(sub1)
             const sub2 = {
                 id: 'sub2Id',
             }
-            subscribedStream.addSubscription(sub2)
-            assert.deepStrictEqual(subscribedStream.getSubscriptions(), [sub1, sub2])
+            subscribedStreamPartition.addSubscription(sub2)
+            assert.deepStrictEqual(subscribedStreamPartition.getSubscriptions(), [sub1, sub2])
         })
         it('should return true', () => {
-            assert.strictEqual(subscribedStream.emptySubscriptionsSet(), true)
+            assert.strictEqual(subscribedStreamPartition.emptySubscriptionsSet(), true)
         })
     })
 })


### PR DESCRIPTION
`SubscribedStream`s were indexed by `streamId` only, and subscriptions to different partitions didn't work. If a client wanted to subscribe to partitions 2, 3, and 4:

```
const handler = (payload, streamMessage) => {
    console.log(`Got message ${JSON.stringify(payload)} from partition ${streamMessage.getStreamPartition()}`)
}

[2,3,4].forEach(partition => {
    client.subscribe(
        {
            stream: 'YRXGkm7dSbWJ2H3c2EsiIw',
            partition: partition,
        },
        handler,
    )
})
```

The client would only send a `SubscribeRequest` for partition 2. The other two calls to `subscribe` would add the handler for partitions 3 and 4 to the existing `SubscribedStream` which was created for partition 2. Due to this, the client would only subscribe to partition 2 and the handler would be called 3 times for each message.

This PR fixes the issue by repurposing and renaming `SubscribedStream` to `SubscribedStreamPartition`, and indexing them by a combination of `streamId + streamPartition`.

Loose end: In `SubscribedStream` (now `SubscribedStreamPartition`), there is some caching of stream objects and stream publishers going on. It is redundant to request and cache these for each subscribed stream-partition, as these are stream-level things. However, I needed to get things working urgently, so I'm leaving the caching refactor out of scope for this PR, and creating a follow-up ticket about it.