### PR TITLE
use request id instead of sub id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,30 @@
 language: node_js
-dist: trusty
 node_js:
 - '8'
-sudo: true
-services:
-- docker
+- '10'
 branches:
   only:
   - master
   - "/^v\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"
 before_install:
-- npm i -g npm@6.0.0
+- npm i -g npm@6.13.0
 jobs:
   include:
-  - stage: eslint
+  - stage: Tests
+    name: Integration Tests
     script:
-    - npm run eslint
-  - stage: Unit tests
+      - sudo /etc/init.d/mysql stop
+      - sudo sysctl fs.inotify.max_user_watches=524288; sudo sysctl -p
+      - git clone https://github.com/streamr-dev/streamr-docker-dev.git
+      - sudo ifconfig docker0 10.200.10.1/24
+      - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 5"
+      - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/users/me); if [ $http_code = 401 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
+      - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/volume); if [ $http_code = 200 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
+      - npm run test-integration
+  - stage: Tests
+    name: Unit Tests
     script:
-    - npm run test-unit
-  - stage: Integration tests
-    script:
-    - sudo /etc/init.d/mysql stop
-    - sudo sysctl fs.inotify.max_user_watches=524288; sudo sysctl -p
-    - git clone https://github.com/streamr-dev/streamr-docker-dev.git
-    - sudo ifconfig docker0 10.200.10.1/24
-    - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 5"
-    - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh log -f &"
-    - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/users/me); if [ $http_code = 401 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
-    - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/volume); if [ $http_code = 200 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
-    - npm run test-integration
+      - npm run test-unit
+  - stage: Tests
+    name: eslint
+    script: npm run eslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '8'
 - '10'
 branches:
   only:

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -38,7 +38,7 @@ export default class AbstractSubscription extends Subscription {
         })
     }
 
-    addPendingResendRequestIds(requestId) {
+    addPendingResendRequestId(requestId) {
         this.pendingResendRequestIds[requestId] = true
     }
 

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -13,6 +13,7 @@ export default class AbstractSubscription extends Subscription {
     constructor(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout, orderMessages = true) {
         super(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout)
         this.callback = callback
+        this.pendingResendRequestIds = {}
         this.orderingUtil = (orderMessages) ? new OrderingUtil(streamId, streamPartition, (orderedMessage) => {
             this._handleInOrder(orderedMessage)
         }, (from, to, publisherId, msgChainId) => {
@@ -35,6 +36,10 @@ export default class AbstractSubscription extends Subscription {
         this.on('error', () => {
             this._clearGaps()
         })
+    }
+
+    addPendingResendRequestIds(requestId) {
+        this.pendingResendRequestIds[requestId] = true
     }
 
     _handleInOrder(orderedMessage) {
@@ -62,8 +67,8 @@ export default class AbstractSubscription extends Subscription {
 
     async handleResending(response) {
         return this._catchAndEmitErrors(() => {
-            if (!this.isResending()) {
-                throw new Error(`There should be no resend in progress, but received ResendResponseResending message ${response.serialize()}`)
+            if (!this.pendingResendRequestIds[response.subId]) { // TODO: use requestId
+                throw new Error(`Received unexpected ResendResponseResending message ${response.serialize()}`)
             }
             this.emit('resending', response)
         })
@@ -71,8 +76,8 @@ export default class AbstractSubscription extends Subscription {
 
     async handleResent(response) {
         return this._catchAndEmitErrors(async () => {
-            if (!this.isResending()) {
-                throw new Error(`There should be no resend in progress, but received ResendResponseResent message ${response.serialize()}`)
+            if (!this.pendingResendRequestIds[response.subId]) { // TODO: use response.requestId
+                throw new Error(`Received unexpected ResendResponseResent message ${response.serialize()}`)
             }
 
             if (!this._lastMessageHandlerPromise) {
@@ -84,6 +89,7 @@ export default class AbstractSubscription extends Subscription {
             try {
                 this.emit('resent', response)
             } finally {
+                delete this.pendingResendRequestIds[response.subId] // TODO: use response.requestId
                 this.finishResend()
             }
         })
@@ -91,12 +97,13 @@ export default class AbstractSubscription extends Subscription {
 
     async handleNoResend(response) {
         return this._catchAndEmitErrors(async () => {
-            if (!this.isResending()) {
-                throw new Error(`There should be no resend in progress, but received ResendResponseNoResend message ${response.serialize()}`)
+            if (!this.pendingResendRequestIds[response.subId]) { // TODO: use response.requestId
+                throw new Error(`Received unexpected ResendResponseNoResend message ${response.serialize()}`)
             }
             try {
                 this.emit('no_resend', response)
             } finally {
+                delete this.pendingResendRequestIds[response.subId] // TODO: use response.requestId
                 this.finishResend(true)
             }
         })

--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -47,8 +47,8 @@ export default class CombinedSubscription extends Subscription {
         return this.sub.stop()
     }
 
-    addPendingResendRequestIds(requestId) {
-        this.sub.addPendingResendRequestIds(requestId)
+    addPendingResendRequestId(requestId) {
+        this.sub.addPendingResendRequestId(requestId)
     }
 
     async handleResentMessage(msg, verifyFn) {

--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -47,6 +47,10 @@ export default class CombinedSubscription extends Subscription {
         return this.sub.stop()
     }
 
+    addPendingResendRequestIds(requestId) {
+        this.sub.addPendingResendRequestIds(requestId)
+    }
+
     async handleResentMessage(msg, verifyFn) {
         return this.sub.handleResentMessage(msg, verifyFn)
     }

--- a/src/RealTimeSubscription.js
+++ b/src/RealTimeSubscription.js
@@ -20,7 +20,9 @@ export default class RealTimeSubscription extends AbstractSubscription {
 
     finishResend() {
         this._lastMessageHandlerPromise = null
-        this.setResending(false)
+        if (Object.keys(this.pendingResendRequestIds).length === 0) {
+            this.setResending(false)
+        }
     }
 
     /* eslint-disable class-methods-use-this */

--- a/src/ResendUtil.js
+++ b/src/ResendUtil.js
@@ -1,4 +1,5 @@
 import EventEmitter from 'eventemitter3'
+import { ControlLayer } from 'streamr-client-protocol'
 
 export default class ResendUtil extends EventEmitter {
     constructor() {
@@ -13,13 +14,15 @@ export default class ResendUtil extends EventEmitter {
         return id.toString()
     }
 
-    getSubFromResendResponse(response, responseType) {
+    getSubFromResendResponse(response, responseTypeName) {
         if (!this.subForRequestId[response.subId]) { // TODO: replace with response.requestId
-            const error = new Error(`Received unexpected ${responseType} message ${response.serialize()}`)
+            const error = new Error(`Received unexpected ${responseTypeName} message ${response.serialize()}`)
             this.emit('error', error)
         }
         const sub = this.subForRequestId[response.subId] // TODO: replace with response.requestId
-        delete this.subForRequestId[response.subId] // each resend response must be handled only once
+        if (response.type !== ControlLayer.ResendResponseResending.TYPE) {
+            delete this.subForRequestId[response.subId] // request handled when "no resend" or "resent" is received
+        }
         return sub
     }
 

--- a/src/ResendUtil.js
+++ b/src/ResendUtil.js
@@ -18,12 +18,15 @@ export default class ResendUtil extends EventEmitter {
             const error = new Error(`Received unexpected ${responseType} message ${response.serialize()}`)
             this.emit('error', error)
         }
-        return this.subForRequestId[response.subId] // TODO: replace with response.requestId
+        const sub = this.subForRequestId[response.subId] // TODO: replace with response.requestId
+        delete this.subForRequestId[response.subId] // each resend response must be handled only once
+        return sub
     }
 
     registerResendRequestForSub(sub) {
         const requestId = this.generateRequestId()
         this.subForRequestId[requestId] = sub
+        sub.addPendingResendRequestIds(requestId)
         return requestId
     }
 }

--- a/src/ResendUtil.js
+++ b/src/ResendUtil.js
@@ -29,7 +29,7 @@ export default class ResendUtil extends EventEmitter {
     registerResendRequestForSub(sub) {
         const requestId = this.generateRequestId()
         this.subForRequestId[requestId] = sub
-        sub.addPendingResendRequestIds(requestId)
+        sub.addPendingResendRequestId(requestId)
         return requestId
     }
 }

--- a/src/ResendUtil.js
+++ b/src/ResendUtil.js
@@ -20,7 +20,7 @@ export default class ResendUtil extends EventEmitter {
             this.emit('error', error)
         }
         const sub = this.subForRequestId[response.subId] // TODO: replace with response.requestId
-        if (response.type !== ControlLayer.ResendResponseResending.TYPE) {
+        if (response.type === ControlLayer.ResendResponseResent.TYPE || response.type === ControlLayer.ResendResponseNoResend.TYPE) {
             delete this.subForRequestId[response.subId] // request handled when "no resend" or "resent" is received
         }
         return sub

--- a/src/ResendUtil.js
+++ b/src/ResendUtil.js
@@ -1,0 +1,29 @@
+import EventEmitter from 'eventemitter3'
+
+export default class ResendUtil extends EventEmitter {
+    constructor() {
+        super()
+        this.subForRequestId = {}
+        this.counter = 0
+    }
+
+    generateRequestId() {
+        const id = this.counter
+        this.counter += 1
+        return id.toString()
+    }
+
+    getSubFromResendResponse(response, responseType) {
+        if (!this.subForRequestId[response.subId]) { // TODO: replace with response.requestId
+            const error = new Error(`Received unexpected ${responseType} message ${response.serialize()}`)
+            this.emit('error', error)
+        }
+        return this.subForRequestId[response.subId] // TODO: replace with response.requestId
+    }
+
+    registerResendRequestForSub(sub) {
+        const requestId = this.generateRequestId()
+        this.subForRequestId[requestId] = sub
+        return requestId
+    }
+}

--- a/src/ResendUtil.js
+++ b/src/ResendUtil.js
@@ -14,16 +14,24 @@ export default class ResendUtil extends EventEmitter {
         return id.toString()
     }
 
-    getSubFromResendResponse(response, responseTypeName) {
-        if (!this.subForRequestId[response.subId]) { // TODO: replace with response.requestId
-            const error = new Error(`Received unexpected ${responseTypeName} message ${response.serialize()}`)
+    _subForRequestIdExists(subId) { // TODO: replace with response.requestId
+        return subId in this.subForRequestId
+    }
+
+    getSubFromResendResponse(response) {
+        if (!this._subForRequestIdExists(response.subId)) { // TODO: replace with response.requestId
+            const error = new Error(`Received unexpected ${response.constructor.name} message ${response.serialize()}`)
             this.emit('error', error)
         }
-        const sub = this.subForRequestId[response.subId] // TODO: replace with response.requestId
+
+        return this.subForRequestId[response.subId] // TODO: replace with response.requestId
+    }
+
+    deleteDoneSubsByResponse(response) {
+        // TODO: replace with response.requestId
         if (response.type === ControlLayer.ResendResponseResent.TYPE || response.type === ControlLayer.ResendResponseNoResend.TYPE) {
             delete this.subForRequestId[response.subId] // request handled when "no resend" or "resent" is received
         }
-        return sub
     }
 
     registerResendRequestForSub(sub) {

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -139,7 +139,6 @@ export default class StreamrClient extends EventEmitter {
             const stream = this._getSubscribedStreamPartition(msg.streamMessage.getStreamId(), msg.streamMessage.getStreamPartition())
             if (stream) {
                 const sub = this.resendUtil.getSubFromResendResponse(msg)
-                this.resendUtil.deleteDoneSubsByResponse(msg)
 
                 if (sub && stream.getSubscription(sub.id)) {
                     // sub.handleResentMessage never rejects: on any error it emits an 'error' event on the Subscription
@@ -182,7 +181,6 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(ResendResponseResending.TYPE, (response) => {
             const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             const sub = this.resendUtil.getSubFromResendResponse(response)
-            this.resendUtil.deleteDoneSubsByResponse(response)
 
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleResending(response)

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -138,7 +138,9 @@ export default class StreamrClient extends EventEmitter {
         this.connection.on(UnicastMessage.TYPE, async (msg) => {
             const stream = this._getSubscribedStreamPartition(msg.streamMessage.getStreamId(), msg.streamMessage.getStreamPartition())
             if (stream) {
-                const sub = this.resendUtil.getSubFromResendResponse(msg, 'UnicastMessage')
+                const sub = this.resendUtil.getSubFromResendResponse(msg)
+                this.resendUtil.deleteDoneSubsByResponse(msg)
+
                 if (sub && stream.getSubscription(sub.id)) {
                     // sub.handleResentMessage never rejects: on any error it emits an 'error' event on the Subscription
                     sub.handleResentMessage(
@@ -179,7 +181,9 @@ export default class StreamrClient extends EventEmitter {
         // Route resending state messages to corresponding Subscriptions
         this.connection.on(ResendResponseResending.TYPE, (response) => {
             const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
-            const sub = this.resendUtil.getSubFromResendResponse(response, 'ResendResponseResending')
+            const sub = this.resendUtil.getSubFromResendResponse(response)
+            this.resendUtil.deleteDoneSubsByResponse(response)
+
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleResending(response)
             } else {
@@ -189,7 +193,9 @@ export default class StreamrClient extends EventEmitter {
 
         this.connection.on(ResendResponseNoResend.TYPE, (response) => {
             const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
-            const sub = this.resendUtil.getSubFromResendResponse(response, 'ResendResponseNoResend')
+            const sub = this.resendUtil.getSubFromResendResponse(response)
+            this.resendUtil.deleteDoneSubsByResponse(response)
+
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleNoResend(response)
             } else {
@@ -199,7 +205,9 @@ export default class StreamrClient extends EventEmitter {
 
         this.connection.on(ResendResponseResent.TYPE, (response) => {
             const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
-            const sub = this.resendUtil.getSubFromResendResponse(response, 'ResendResponseResent')
+            const sub = this.resendUtil.getSubFromResendResponse(response)
+            this.resendUtil.deleteDoneSubsByResponse(response)
+
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleResent(response)
             } else {

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -210,7 +210,7 @@ describe('StreamrClient Connection', () => {
                 ])
                 done()
             })
-        }, 300000)
+        })
 
         it('resend range', async (done) => {
             const messages = []

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -210,7 +210,7 @@ describe('StreamrClient Connection', () => {
                 ])
                 done()
             })
-        })
+        }, 300000)
 
         it('resend range', async (done) => {
             const messages = []

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -1,4 +1,4 @@
 module.exports = {
     websocketUrl: process.env.WEBSOCKET_URL || 'ws://localhost/api/v1/ws',
-    restUrl: process.env.REST_URL || 'http://localhost/streamr-core/api/v1',
+    restUrl: process.env.REST_URL || 'http://localhost:8081/streamr-core/api/v1',
 }

--- a/test/unit/CombinedSubscription.test.js
+++ b/test/unit/CombinedSubscription.test.js
@@ -27,7 +27,7 @@ describe('CombinedSubscription', () => {
         const sub = new CombinedSubscription(msg1.getStreamId(), msg1.getStreamPartition(), sinon.stub(), {
             last: 1
         }, {}, 100, 100)
-        sub.addPendingResendRequestIds('requestId')
+        sub.addPendingResendRequestId('requestId')
         sub.on('gap', (from, to, publisherId) => {
             assert.equal(from.timestamp, 1)
             assert.equal(from.sequenceNumber, 1)

--- a/test/unit/CombinedSubscription.test.js
+++ b/test/unit/CombinedSubscription.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert'
 
 import sinon from 'sinon'
-import { MessageLayer } from 'streamr-client-protocol'
+import { ControlLayer, MessageLayer } from 'streamr-client-protocol'
 
 import CombinedSubscription from '../../src/CombinedSubscription'
 
@@ -27,6 +27,7 @@ describe('CombinedSubscription', () => {
         const sub = new CombinedSubscription(msg1.getStreamId(), msg1.getStreamPartition(), sinon.stub(), {
             last: 1
         }, {}, 100, 100)
+        sub.addPendingResendRequestIds('requestId')
         sub.on('gap', (from, to, publisherId) => {
             assert.equal(from.timestamp, 1)
             assert.equal(from.sequenceNumber, 1)
@@ -38,9 +39,9 @@ describe('CombinedSubscription', () => {
                 done()
             }, 100)
         })
-        sub.handleResending()
+        sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'requestId'))
         sub.handleResentMessage(msg1, sinon.stub().resolves(true))
         sub.handleBroadcastMessage(msg4, sinon.stub().resolves(true))
-        sub.handleResent()
+        sub.handleResent(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId'))
     })
 })

--- a/test/unit/HistoricalSubscription.test.js
+++ b/test/unit/HistoricalSubscription.test.js
@@ -9,7 +9,6 @@ import InvalidSignatureError from '../../src/errors/InvalidSignatureError'
 import VerificationFailedError from '../../src/errors/VerificationFailedError'
 import EncryptionUtil from '../../src/EncryptionUtil'
 import Subscription from '../../src/Subscription'
-import RealTimeSubscription from '../../src/RealTimeSubscription'
 
 const { StreamMessage } = MessageLayer
 
@@ -561,8 +560,9 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub(), {
                 last: 1
             })
+            sub.addPendingResendRequestIds('requestId')
             sub.on('resending', () => done())
-            sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'subId'))
+            sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'requestId'))
         })
     })
 
@@ -572,9 +572,10 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), handler, {
                 last: 1
             })
+            sub.addPendingResendRequestIds('requestId')
             sub.on('resent', () => done())
             await sub.handleResentMessage(msg, sinon.stub().resolves(true))
-            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
+            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
         })
 
         it('arms the Subscription to emit the resent event on last message (message handler completes AFTER resent)', async (done) => {
@@ -582,9 +583,10 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), handler, {
                 last: 1
             })
+            sub.addPendingResendRequestIds('requestId')
             sub.on('resent', () => done())
             sub.handleResentMessage(msg, sinon.stub().resolves(true))
-            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
+            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
         })
     })
 
@@ -593,8 +595,9 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub(), {
                 last: 1
             })
+            sub.addPendingResendRequestIds('requestId')
             sub.on('no_resend', () => done())
-            sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'subId'))
+            sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId'))
         })
     })
 })

--- a/test/unit/HistoricalSubscription.test.js
+++ b/test/unit/HistoricalSubscription.test.js
@@ -560,7 +560,7 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub(), {
                 last: 1
             })
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('resending', () => done())
             sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'requestId'))
         })
@@ -572,7 +572,7 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), handler, {
                 last: 1
             })
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('resent', () => done())
             await sub.handleResentMessage(msg, sinon.stub().resolves(true))
             sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
@@ -583,7 +583,7 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), handler, {
                 last: 1
             })
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('resent', () => done())
             sub.handleResentMessage(msg, sinon.stub().resolves(true))
             sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
@@ -595,7 +595,7 @@ describe('HistoricalSubscription', () => {
             const sub = new HistoricalSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub(), {
                 last: 1
             })
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('no_resend', () => done())
             sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId'))
         })

--- a/test/unit/RealTimeSubscription.test.js
+++ b/test/unit/RealTimeSubscription.test.js
@@ -598,9 +598,10 @@ describe('RealTimeSubscription', () => {
     describe('handleResending()', () => {
         it('emits the resending event', (done) => {
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
+            sub.addPendingResendRequestIds('requestId')
             sub.on('resending', () => done())
             sub.setResending(true)
-            sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'subId'))
+            sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'requestId'))
         })
     })
 
@@ -608,19 +609,21 @@ describe('RealTimeSubscription', () => {
         it('arms the Subscription to emit the resent event on last message (message handler completes BEFORE resent)', async (done) => {
             const handler = sinon.stub()
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), handler)
+            sub.addPendingResendRequestIds('requestId')
             sub.on('resent', () => done())
             sub.setResending(true)
             await sub.handleResentMessage(msg, sinon.stub().resolves(true))
-            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
+            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
         })
 
         it('arms the Subscription to emit the resent event on last message (message handler completes AFTER resent)', async (done) => {
             const handler = sinon.stub()
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), handler)
+            sub.addPendingResendRequestIds('requestId')
             sub.on('resent', () => done())
             sub.setResending(true)
             sub.handleResentMessage(msg, sinon.stub().resolves(true))
-            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
+            sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
         })
 
         describe('on error', () => {
@@ -641,11 +644,12 @@ describe('RealTimeSubscription', () => {
                 const handler = sinon.stub()
                 sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), handler)
                 const error = new Error('test error, ignore')
+                sub.addPendingResendRequestIds('requestId')
                 sub.on('resent', sinon.stub().throws(error))
                 sub.setResending(true)
                 await sub.handleResentMessage(msg, sinon.stub().resolves(true))
 
-                await sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'))
+                await sub.handleResent(ControlLayer.ResendResponseResent.create('streamId', 0, 'requestId'))
                 assert(!sub.isResending())
             })
         })
@@ -654,9 +658,10 @@ describe('RealTimeSubscription', () => {
     describe('handleNoResend()', () => {
         it('emits the no_resend event', (done) => {
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
+            sub.addPendingResendRequestIds('requestId')
             sub.on('no_resend', () => done())
             sub.setResending(true)
-            sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'subId'))
+            sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId'))
         })
 
         describe('on error', () => {
@@ -676,10 +681,11 @@ describe('RealTimeSubscription', () => {
             it('cleans up the resend if event handler throws', async () => {
                 sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
                 const error = new Error('test error, ignore')
+                sub.addPendingResendRequestIds('requestId')
                 sub.on('no_resend', sinon.stub()
                     .throws(error))
                 sub.setResending(true)
-                await sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'subId'))
+                await sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId'))
                 assert(!sub.isResending())
             })
         })

--- a/test/unit/RealTimeSubscription.test.js
+++ b/test/unit/RealTimeSubscription.test.js
@@ -598,7 +598,7 @@ describe('RealTimeSubscription', () => {
     describe('handleResending()', () => {
         it('emits the resending event', (done) => {
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('resending', () => done())
             sub.setResending(true)
             sub.handleResending(ControlLayer.ResendResponseResending.create('streamId', 0, 'requestId'))
@@ -609,7 +609,7 @@ describe('RealTimeSubscription', () => {
         it('arms the Subscription to emit the resent event on last message (message handler completes BEFORE resent)', async (done) => {
             const handler = sinon.stub()
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), handler)
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('resent', () => done())
             sub.setResending(true)
             await sub.handleResentMessage(msg, sinon.stub().resolves(true))
@@ -619,7 +619,7 @@ describe('RealTimeSubscription', () => {
         it('arms the Subscription to emit the resent event on last message (message handler completes AFTER resent)', async (done) => {
             const handler = sinon.stub()
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), handler)
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('resent', () => done())
             sub.setResending(true)
             sub.handleResentMessage(msg, sinon.stub().resolves(true))
@@ -644,7 +644,7 @@ describe('RealTimeSubscription', () => {
                 const handler = sinon.stub()
                 sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), handler)
                 const error = new Error('test error, ignore')
-                sub.addPendingResendRequestIds('requestId')
+                sub.addPendingResendRequestId('requestId')
                 sub.on('resent', sinon.stub().throws(error))
                 sub.setResending(true)
                 await sub.handleResentMessage(msg, sinon.stub().resolves(true))
@@ -658,7 +658,7 @@ describe('RealTimeSubscription', () => {
     describe('handleNoResend()', () => {
         it('emits the no_resend event', (done) => {
             const sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
-            sub.addPendingResendRequestIds('requestId')
+            sub.addPendingResendRequestId('requestId')
             sub.on('no_resend', () => done())
             sub.setResending(true)
             sub.handleNoResend(ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId'))
@@ -681,7 +681,7 @@ describe('RealTimeSubscription', () => {
             it('cleans up the resend if event handler throws', async () => {
                 sub = new RealTimeSubscription(msg.getStreamId(), msg.getStreamPartition(), sinon.stub())
                 const error = new Error('test error, ignore')
-                sub.addPendingResendRequestIds('requestId')
+                sub.addPendingResendRequestId('requestId')
                 sub.on('no_resend', sinon.stub()
                     .throws(error))
                 sub.setResending(true)

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -465,7 +465,7 @@ describe('StreamrClient', () => {
                 connection.emitMessage(resendResponse)
                 sinon.assert.calledWith(sub.handleResending, resendResponse)
             })
-            it('throws when unknown request id', (done) => {
+            it('emits error when unknown request id', (done) => {
                 sub.handleResending = sinon.stub().throws()
                 const resendResponse = ResendResponseResending.create(sub.streamId, sub.streamPartition, 'unknown request id')
                 client.on('error', (err) => {

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -469,7 +469,7 @@ describe('StreamrClient', () => {
                 sub.handleResending = sinon.stub().throws()
                 const resendResponse = ResendResponseResending.create(sub.streamId, sub.streamPartition, 'unknown request id')
                 client.on('error', (err) => {
-                    assert.deepStrictEqual(err.message, `Received unexpected ResendResponseResending message ${resendResponse.serialize()}`)
+                    assert.deepStrictEqual(err.message, `Received unexpected ResendResponseResendingV1 message ${resendResponse.serialize()}`)
                     done()
                 })
                 connection.emitMessage(resendResponse)
@@ -499,7 +499,7 @@ describe('StreamrClient', () => {
                 sub.handleNoResend = sinon.stub().throws()
                 const resendResponse = ResendResponseNoResend.create(sub.streamId, sub.streamPartition, 'unknown request id')
                 client.on('error', (err) => {
-                    assert.deepStrictEqual(err.message, `Received unexpected ResendResponseNoResend message ${resendResponse.serialize()}`)
+                    assert.deepStrictEqual(err.message, `Received unexpected ResendResponseNoResendV1 message ${resendResponse.serialize()}`)
                     done()
                 })
                 connection.emitMessage(resendResponse)
@@ -529,7 +529,7 @@ describe('StreamrClient', () => {
                 sub.handleResent = sinon.stub().throws()
                 const resendResponse = ResendResponseResent.create(sub.streamId, sub.streamPartition, 'unknown request id')
                 client.on('error', (err) => {
-                    assert.deepStrictEqual(err.message, `Received unexpected ResendResponseResent message ${resendResponse.serialize()}`)
+                    assert.deepStrictEqual(err.message, `Received unexpected ResendResponseResentV1 message ${resendResponse.serialize()}`)
                     done()
                 })
                 connection.emitMessage(resendResponse)


### PR DESCRIPTION
WIP

This PR changes the way resend requests and responses are coordinated. They used to be linked with the subscription id (which lead to problems when multiple resends were happening at the same time within a same subscription but different message chains). Now they use specific request ids.

This PR is blocked by this other PR: https://github.com/streamr-dev/streamr-client-protocol-js/pull/23