### PR TITLE
Handle the case where $http_code is not set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jobs:
       - git clone https://github.com/streamr-dev/streamr-docker-dev.git
       - sudo ifconfig docker0 10.200.10.1/24
       - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 5"
-      - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/users/me); if [ $http_code = 401 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
-      - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/volume); if [ $http_code = 200 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
+      - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/users/me); if [ -z $http_code ] || [ $http_code = 401 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
+      - while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/volume);  if [ -z $http_code ] || [ $http_code = 200 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
       - npm run test-integration
   - stage: Tests
     name: Unit Tests


### PR DESCRIPTION
this seems to cause lots of "/home/travis/.travis/functions: line 109: [: =: unary operator expected" messages in Travis