### PR TITLE
Disable Regenerator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,23 +1,34 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "modules": false,
-        "loose": false,
-        "targets": {
-          "browsers": [
-            "last 2 versions"]
-        }
-      }
+    "presets": [
+        ["@babel/preset-env", {
+            "useBuiltIns": "usage",
+            "modules": false,
+            "corejs": 3,
+            "loose": false,
+            "targets": {
+                "browsers": [
+                    "> 1.5%",
+                    "Opera >= 58",
+                    "Safari >= 12",
+                    "Edge >= 75",
+                    "Firefox ESR",
+                    "not dead",
+                    "not ie <= 11",
+                    "not ie_mob <= 11"
+                ]
+            }
+        }]
+    ],
+    "plugins": [
+        "add-module-exports",
+        ["@babel/plugin-transform-runtime", {
+            "corejs": false,
+            "helpers": true,
+            "regenerator": false
+        }],
+        "@babel/plugin-transform-modules-commonjs",
+        ["@babel/plugin-proposal-class-properties", {
+            "loose": false
+        }]
     ]
-  ],
-  "plugins": [
-    "add-module-exports",
-    "@babel/plugin-transform-runtime",
-    "@babel/plugin-transform-modules-commonjs",
-    ["@babel/plugin-proposal-class-properties",
-      { "loose": false }
-    ]
-  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2295,6 +2295,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -3228,9 +3234,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
+      "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "core-js": "^3.6.0",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-streamr-nodejs": "^1.1.0",

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -203,11 +203,10 @@ describe('StreamrClient', () => {
             })
 
             it('should not subscribe to unsubscribed streams on reconnect', (done) => {
-                // TODO check
-                // On unsubscribe
-                connection.expect(UnsubscribeRequest.create('stream1'))
                 // On connect
                 connection.expect(SubscribeRequest.create('stream1', 0, 'session-token'))
+                // On unsubscribe
+                connection.expect(UnsubscribeRequest.create('stream1'))
 
                 const sub = client.subscribe('stream1', () => {})
                 client.connect().then(() => {


### PR DESCRIPTION
Builds on top of #107.

In trying to figure out what's going on with the assertion order change mentioned in #107, I disabled `regenerator` so I could see the stack trace correctly and voila once it was using real async/await the original assertion order worked.

The `preset-env` `"last two versions"` config includes IE11 (or some other browser) which requires transpiling `async`/`await` with `regenerator`. Copied/adapted our browser support list & `core-js`/`runtime`/`preset-env` config [across from streamr-platform](https://github.com/streamr-dev/streamr-platform/blob/6d368300108d54cab707a03b029b7e588a10ea25/app/babel.config.js). 

This should make debugging overall easier since you will be able to see real async stack traces now. 