### PR TITLE
Fix ethers imports and test build step

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,3 +47,6 @@ jobs:
         while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/users/me); if [ "$http_code" = 401 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
         while true; do http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/v1/volume); if [ "$http_code" = 200 ]; then echo "brokers up and running"; break; else echo "brokers not receiving connections"; sleep 5s; fi; done
         npm run test-integration
+
+    - name: test-build
+      run: npm run build

--- a/src/rest/CommunityEndpoints.js
+++ b/src/rest/CommunityEndpoints.js
@@ -15,17 +15,15 @@ import {
     Wallet,
     getDefaultProvider,
     providers,
+    utils as ethersUtils,
 } from 'ethers'
-import {
-    BigNumber,
-    computeAddress,
-    getAddress
-} from 'ethers/utils'
 import debugFactory from 'debug'
 
 import * as CommunityProduct from '../../contracts/CommunityProduct.json'
 
 import authFetch from './authFetch'
+
+const { BigNumber, computeAddress, getAddress } = ethersUtils
 
 const debug = debugFactory('StreamrClient::CommunityEndpoints')
 


### PR DESCRIPTION
Webpack chokes on imports to `child_process` & `fs` when building scripts imported out of `ethers/utils`.  Fixed by importing `utils` off the main `ethers` export.

Also added checking of the build step to CI so future build issues will be identified at the PR stage.