### PR TITLE
fix subscribe on reconnect after resend only

### DIFF
--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -95,4 +95,8 @@ export default class CombinedSubscription extends Subscription {
     handleError(err) {
         return this.sub.handleError(err)
     }
+
+    onDisconnected() {
+        this.sub.onDisconnected()
+    }
 }

--- a/src/HistoricalSubscription.js
+++ b/src/HistoricalSubscription.js
@@ -47,4 +47,8 @@ export default class HistoricalSubscription extends AbstractSubscription {
             this.emit('initial_resend_done')
         }
     }
+
+    /* eslint-disable class-methods-use-this */
+    onDisconnected() {}
+    /* eslint-enable class-methods-use-this */
 }

--- a/src/RealTimeSubscription.js
+++ b/src/RealTimeSubscription.js
@@ -1,5 +1,6 @@
 import debugFactory from 'debug'
 
+import Subscription from './Subscription'
 import AbstractSubscription from './AbstractSubscription'
 
 const debug = debugFactory('StreamrClient::Subscription')
@@ -39,5 +40,9 @@ export default class RealTimeSubscription extends AbstractSubscription {
     setResending(resending) {
         debug(`Subscription: Stream ${this.streamId} resending: ${resending}`)
         this.resending = resending
+    }
+
+    onDisconnected() {
+        this.setState(Subscription.State.unsubscribed)
     }
 }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -403,7 +403,7 @@ export default class StreamrClient extends EventEmitter {
         // TODO remove _addSubscription after uncoupling Subscription and Resend
         sub.setState(Subscription.State.subscribed)
         this._addSubscription(sub)
-        sub.on('initial_resend_done', () => this._removeSubscription(sub))
+        sub.once('initial_resend_done', () => this._removeSubscription(sub))
         await this._requestResend(sub)
         return sub
     }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -243,7 +243,7 @@ export default class StreamrClient extends EventEmitter {
                     const stream = this.subscribedStreamPartitions[key]
                     stream.setSubscribing(false)
                     stream.getSubscriptions().forEach((sub) => {
-                        sub.setState(Subscription.State.unsubscribed)
+                        sub.onDisconnected()
                     })
                 })
         })
@@ -401,9 +401,10 @@ export default class StreamrClient extends EventEmitter {
             this.options.subscriberGroupKeys[options.stream], this.options.gapFillTimeout, this.options.retryResendAfter, this.options.orderMessages)
 
         // TODO remove _addSubscription after uncoupling Subscription and Resend
+        sub.setState(Subscription.State.subscribed)
         this._addSubscription(sub)
+        sub.on('initial_resend_done', () => this._removeSubscription(sub))
         await this._requestResend(sub)
-
         return sub
     }
 

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -44,6 +44,12 @@ export default class Subscription extends EventEmitter {
         this.state = state
         this.emit(state)
     }
+
+    /* eslint-disable class-methods-use-this */
+    onDisconnected() {
+        throw new Error('Must be defined in child class')
+    }
+    /* eslint-enable class-methods-use-this */
 }
 
 Subscription.State = {


### PR DESCRIPTION
Prevents resend() to send a subscribe request on reconnection. Currently it does nothing else (it does not send the resend request again).