### PR TITLE
add check

### DIFF
--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -668,6 +668,9 @@ describe('StreamrClient', () => {
         client = createClient()
         await client.ensureConnected()
         stream = await createStream()
+        const publisherId = await client.getPublisherId()
+        const res = await client.isStreamPublisher(stream.id, publisherId.toLowerCase())
+        assert.strictEqual(res, true)
     })
 
     afterEach(async () => {


### PR DESCRIPTION
One thing that could go wrong is that the Ethereum address as a hex string needs to be lower case for the endpoint to return true. That could be improved, could be in the client's method `isStreamPublisher` but IMO would be better to ensure lower case addresses in `engine-and-editor`.