### PR TITLE
Add failing tests for concurrent resend + subscribe.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.7.tgz",
-      "integrity": "sha512-kr3W3Fw8mB/CTru2M5zIRQZZgC/9zOxNSoJ/tVCzjPt3H1/p5uuGbz6WwmaQy/TLQcW31rUhUUWKY28sXFRelA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
+      "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
@@ -3261,9 +3261,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.1.tgz",
-      "integrity": "sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -9885,9 +9885,9 @@
       "dev": true
     },
     "streamr-client-protocol": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-4.0.6.tgz",
-      "integrity": "sha512-j+5fD4/kxnjDQGZmV/2/nj2onm65XpHDUDhsL3w4i+yATQpL/hGB4l7/Gi2E3s5VxC+EoVSV/QUJmQmpypDU1g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-4.1.1.tgz",
+      "integrity": "sha512-BvdVjKdpooLhoIj1PjCLOaTiZzmPOWPsU03+RgPVfs/mPTJz2eRQ1pTxj8sphQ6nvcb6VH8XCP7JfyKuRLWgEA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.4.5",
         "debug": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "qs": "^6.9.1",
     "randomstring": "^1.1.5",
     "receptacle": "^1.3.2",
-    "streamr-client-protocol": "^4.0.6",
+    "streamr-client-protocol": "^4.1.1",
     "webpack-node-externals": "^1.7.2",
     "ws": "^7.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "JavaScript client library for Streamr",
   "repository": {
     "type": "git",

--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -99,4 +99,8 @@ export default class CombinedSubscription extends Subscription {
     onDisconnected() {
         this.sub.onDisconnected()
     }
+
+    isResending() {
+        return this.sub.isResending()
+    }
 }

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -647,7 +647,16 @@ export default class StreamrClient extends EventEmitter {
 
     async _requestSubscribe(sub) {
         const sp = this._getSubscribedStreamPartition(sub.streamId, sub.streamPartition)
-        const subscribedSubs = sp.getSubscriptions().filter((it) => it.getState() === Subscription.State.subscribed)
+        let subscribedSubs = []
+        // never reuse subscriptions when incoming subscription needs resends
+        // i.e. only reuse realtime subscriptions
+        if (!sub.hasResendOptions()) {
+            subscribedSubs = sp.getSubscriptions().filter((it) => (
+                it.getState() === Subscription.State.subscribed
+                // don't resuse subscriptions currently resending
+                && !it.isResending()
+            ))
+        }
 
         const sessionToken = await this.session.getSessionToken()
 

--- a/test/integration/Resends.test.js
+++ b/test/integration/Resends.test.js
@@ -78,12 +78,14 @@ describe('StreamrClient resends', () => {
                     realtimeMessages.push(message)
                 })
 
-                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
-                await client.publish(stream.id, realtimeMessage)
-                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 5000)
+                await Promise.all([
+                    client.publish(stream.id, realtimeMessage),
+                    waitForCondition(() => realtimeMessages.length === 1, 10000)
+                ])
                 expect(resentMessages).toStrictEqual(publishedMessages)
                 expect(realtimeMessages).toStrictEqual([realtimeMessage])
-            }, 10000)
+            }, 18000)
 
             it('works with subscribe -> resend', async () => {
                 const resentMessages = []
@@ -109,12 +111,14 @@ describe('StreamrClient resends', () => {
                     resentMessages.push(message)
                 })
 
-                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
-                await client.publish(stream.id, realtimeMessage)
-                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 5000)
+                await Promise.all([
+                    client.publish(stream.id, realtimeMessage),
+                    waitForCondition(() => realtimeMessages.length === 1, 5000)
+                ])
                 expect(resentMessages).toStrictEqual(publishedMessages)
                 expect(realtimeMessages).toStrictEqual([realtimeMessage])
-            }, 10000)
+            }, 15000)
 
             it('works with subscribe+resend -> subscribe', async () => {
                 const resentMessages = []
@@ -139,12 +143,14 @@ describe('StreamrClient resends', () => {
                     realtimeMessages.push(message)
                 })
 
-                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
-                await client.publish(stream.id, realtimeMessage)
-                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 5000)
+                await Promise.all([
+                    client.publish(stream.id, realtimeMessage),
+                    waitForCondition(() => realtimeMessages.length === 1, 5000)
+                ])
                 expect(resentMessages).toStrictEqual([...publishedMessages, realtimeMessage])
                 expect(realtimeMessages).toStrictEqual([realtimeMessage])
-            }, 10000)
+            }, 15000)
 
             it('works with subscribe -> subscribe+resend', async () => {
                 const resentMessages = []
@@ -170,12 +176,14 @@ describe('StreamrClient resends', () => {
                     resentMessages.push(message)
                 })
 
-                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
-                await client.publish(stream.id, realtimeMessage)
-                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 5000)
+                await Promise.all([
+                    client.publish(stream.id, realtimeMessage),
+                    waitForCondition(() => realtimeMessages.length === 1, 5000)
+                ])
                 expect(resentMessages).toStrictEqual([...publishedMessages, realtimeMessage])
                 expect(realtimeMessages).toStrictEqual([realtimeMessage])
-            }, 10000)
+            }, 15000)
         })
 
         for (let i = 0; i < TEST_REPEATS; i++) {

--- a/test/integration/Resends.test.js
+++ b/test/integration/Resends.test.js
@@ -54,65 +54,129 @@ describe('StreamrClient resends', () => {
             await client.ensureDisconnected()
         })
 
-        it('can issue resend and subscribe at the same time', async () => {
-            const resentMessages = []
-            const realtimeMessages = []
+        describe('issue resend and subscribe at the same time', () => {
+            it('works with resend -> subscribe', async () => {
+                const resentMessages = []
+                const realtimeMessages = []
 
-            const realtimeMessage = {
-                msg: uid('realtimeMessage'),
-            }
+                const realtimeMessage = {
+                    msg: uid('realtimeMessage'),
+                }
 
-            await client.resend({
-                stream: stream.id,
-                resend: {
-                    last: MAX_MESSAGES,
-                },
-            }, (message) => {
-                resentMessages.push(message)
-            })
+                await client.resend({
+                    stream: stream.id,
+                    resend: {
+                        last: MAX_MESSAGES,
+                    },
+                }, (message) => {
+                    resentMessages.push(message)
+                })
 
-            client.subscribe({
-                stream: stream.id,
-            }, (message) => {
-                realtimeMessages.push(message)
-            })
+                client.subscribe({
+                    stream: stream.id,
+                }, (message) => {
+                    realtimeMessages.push(message)
+                })
 
-            await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
-            await client.publish(stream.id, realtimeMessage)
-            await waitForCondition(() => realtimeMessages.length === 1, 10000)
-            expect(resentMessages).toStrictEqual(publishedMessages)
-            expect(realtimeMessages).toStrictEqual([realtimeMessage])
-        }, 10000)
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
+                await client.publish(stream.id, realtimeMessage)
+                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                expect(resentMessages).toStrictEqual(publishedMessages)
+                expect(realtimeMessages).toStrictEqual([realtimeMessage])
+            }, 10000)
 
-        it('can issue subscribe with resend and subscribe at the same time', async () => {
-            const resentMessages = []
-            const realtimeMessages = []
+            it('works with subscribe -> resend', async () => {
+                const resentMessages = []
+                const realtimeMessages = []
 
-            const realtimeMessage = {
-                msg: uid('realtimeMessage'),
-            }
+                const realtimeMessage = {
+                    msg: uid('realtimeMessage'),
+                }
 
-            client.subscribe({
-                stream: stream.id,
-                resend: {
-                    last: MAX_MESSAGES,
-                },
-            }, (message) => {
-                resentMessages.push(message)
-            })
+                client.subscribe({
+                    stream: stream.id,
+                }, (message) => {
+                    realtimeMessages.push(message)
+                })
 
-            client.subscribe({
-                stream: stream.id,
-            }, (message) => {
-                realtimeMessages.push(message)
-            })
+                // resend after realtime subscribe
+                await client.resend({
+                    stream: stream.id,
+                    resend: {
+                        last: MAX_MESSAGES,
+                    },
+                }, (message) => {
+                    resentMessages.push(message)
+                })
 
-            await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
-            await client.publish(stream.id, realtimeMessage)
-            await waitForCondition(() => realtimeMessages.length === 1, 10000)
-            expect(resentMessages).toStrictEqual([...publishedMessages, realtimeMessage])
-            expect(realtimeMessages).toStrictEqual([realtimeMessage])
-        }, 10000)
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
+                await client.publish(stream.id, realtimeMessage)
+                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                expect(resentMessages).toStrictEqual(publishedMessages)
+                expect(realtimeMessages).toStrictEqual([realtimeMessage])
+            }, 10000)
+
+            it('works with subscribe+resend -> subscribe', async () => {
+                const resentMessages = []
+                const realtimeMessages = []
+
+                const realtimeMessage = {
+                    msg: uid('realtimeMessage'),
+                }
+
+                client.subscribe({
+                    stream: stream.id,
+                    resend: {
+                        last: MAX_MESSAGES,
+                    },
+                }, (message) => {
+                    resentMessages.push(message)
+                })
+
+                client.subscribe({
+                    stream: stream.id,
+                }, (message) => {
+                    realtimeMessages.push(message)
+                })
+
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
+                await client.publish(stream.id, realtimeMessage)
+                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                expect(resentMessages).toStrictEqual([...publishedMessages, realtimeMessage])
+                expect(realtimeMessages).toStrictEqual([realtimeMessage])
+            }, 10000)
+
+            it('works with subscribe -> subscribe+resend', async () => {
+                const resentMessages = []
+                const realtimeMessages = []
+
+                const realtimeMessage = {
+                    msg: uid('realtimeMessage'),
+                }
+
+                client.subscribe({
+                    stream: stream.id,
+                }, (message) => {
+                    realtimeMessages.push(message)
+                })
+
+                // subscribe with resend after realtime subscribe
+                client.subscribe({
+                    stream: stream.id,
+                    resend: {
+                        last: MAX_MESSAGES,
+                    },
+                }, (message) => {
+                    resentMessages.push(message)
+                })
+
+                await waitForCondition(() => resentMessages.length === MAX_MESSAGES, 10000)
+                await client.publish(stream.id, realtimeMessage)
+                await waitForCondition(() => realtimeMessages.length === 1, 10000)
+                expect(resentMessages).toStrictEqual([...publishedMessages, realtimeMessage])
+                expect(realtimeMessages).toStrictEqual([realtimeMessage])
+            }, 10000)
+        })
 
         for (let i = 0; i < TEST_REPEATS; i++) {
             // eslint-disable-next-line no-loop-func

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -408,6 +408,7 @@ describe('StreamrClient', () => {
 
                 // this sub's handler must not be called
                 const sub2 = setupSubscription('stream1')
+                connection.expect(SubscribeRequest.create('stream1', 0, 'session-token'))
                 sub2.handleResentMessage = sinon.stub().throws()
 
                 const msg1 = msg(sub.streamId, {}, '0')


### PR DESCRIPTION
When issuing both resend & realtime subscription requests for the same stream, the realtime subscription is never created.

The tests in this PR pass against streamr-client 3.1.2, but not against 3.1.3. 

[Diff between 3.1.2 & 3.13](https://github.com/streamr-dev/streamr-client-javascript/compare/bddbea18...c43591d)

Concrete problem occurs in the data union server which issues concurrent resend + subscribe requests for the same stream: https://github.com/streamr-dev/streamr-community-products/blob/640dfa45f4f520ea40602052101f85e295a50528/src/streamrChannel.js#L110-L127

```JS
        log(`Starting playback of ${this.stream.id}`)
        const playbackSub = await this.client.resend({
            stream: this.stream.id,
            resend: {
                from: {
                    timestamp: syncStartTimestamp || 1,
                    sequenceNumber: 0,
                },
            },
        }, emitMessage)

        const queue = []
        this.client.subscribe({
            stream: this.stream.id
        }, (msg, meta) => {
            const len = queue.push({msg, meta})
            log(`Got message ${JSON.stringify(msg)}, queue length = ${len}}`)
        })
```

The data union server perhaps could achieve the desired result without this, however I believe the client is definitely misbehaving here.

Also interestingly, this doesn't *seem* to be causing an issue with the production data union server, which is using client 3.1.3. It's possible the async timings in production somehow work around the issue, though it's not proven this issue is definitely never happening in production, perhaps it's intermittent.

----

When the `.subscribe` occurs after the `.resend`, `client._requestSubscribe` erroneously considers the resend subscription a duplicate subscription, and "insta-subscribes" to it:
https://github.com/streamr-dev/streamr-client-javascript/blob/c43591d617a0f167d82d44bee477a780dac3936e/src/StreamrClient.js#L648-L668

and then immediately unsubscribes the realtime subscription as soon as the resend is finished:
https://github.com/streamr-dev/streamr-client-javascript/blob/f652138d47d642746a840ef715cc61da59c8bb02/src/StreamrClient.js#L406

----

Issue appears to be triggered by this change in `3.1.3` that immediately adds `sub.setState(Subscription.State.subscribed)` to the historical subscription:
https://github.com/streamr-dev/streamr-client-javascript/commit/f652138d47d642746a840ef715cc61da59c8bb02#diff-490b0cafe3e660b3fba36db4786f005aR404

However I think the bug is actually in the way `_requestSubscribe` detects duplicate subscriptions, which in turn is really a shortcoming in how subscriptions are keyed into `client.subscribedStreamPartitions` i.e. subscriptions with the same id+partition but entirely different resend options are considered the same subscription.

https://github.com/streamr-dev/streamr-client-javascript/blob/c43591d617a0f167d82d44bee477a780dac3936e/src/StreamrClient.js#L275-L294