### PR TITLE
Ignore case of userId when checking permissions.

### DIFF
--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -55,7 +55,7 @@ export default class Stream {
             if (userId === undefined) {
                 return !!p.anonymous // match nullish userId against p.anonymous
             }
-            return p.user.toLowerCase() === userIdCaseInsensitive // match against userId
+            return p.user && p.user.toLowerCase() === userIdCaseInsensitive // match against userId
         })
     }
 

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -47,16 +47,25 @@ export default class Stream {
 
     async hasPermission(operation, userId) {
         const permissions = await this.getPermissions()
-        return permissions.find((p) => p.operation === operation && ((userId == null && p.anonymous) || (userId != null && p.user === userId)))
+        // eth addresses may be in checksumcase, but userId from server has no case
+        const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : userId
+        return permissions.find((p) => (
+            p.operation === operation
+            && (
+                (userId == null && p.anonymous)
+                || (userId != null && p.user.toLowerCase() === userIdCaseInsensitive)
+            )
+        ))
     }
 
     grantPermission(operation, userId) {
         const permissionObject = {
             operation,
         }
+        const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : userId
 
         if (userId != null) {
-            permissionObject.user = userId
+            permissionObject.user = userIdCaseInsensitive
         } else {
             permissionObject.anonymous = true
         }

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -47,12 +47,12 @@ export default class Stream {
 
     async hasPermission(operation, userId) {
         // eth addresses may be in checksumcase, but userId from server has no case
-        const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : userId
+        const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : undefined // if not string then undefined
         const permissions = await this.getPermissions()
         return permissions.find((p) => {
             if (p.operation !== operation) { return false }
 
-            if (userId == null) {
+            if (userId === undefined) {
                 return !!p.anonymous // match nullish userId against p.anonymous
             }
             return p.user.toLowerCase() === userIdCaseInsensitive // match against userId
@@ -63,7 +63,7 @@ export default class Stream {
         const permissionObject = {
             operation,
         }
-        const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : userId
+        const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : undefined
 
         if (userId != null) {
             permissionObject.user = userIdCaseInsensitive

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -46,16 +46,17 @@ export default class Stream {
     }
 
     async hasPermission(operation, userId) {
-        const permissions = await this.getPermissions()
         // eth addresses may be in checksumcase, but userId from server has no case
         const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : userId
-        return permissions.find((p) => (
-            p.operation === operation
-            && (
-                (userId == null && p.anonymous)
-                || (userId != null && p.user.toLowerCase() === userIdCaseInsensitive)
-            )
-        ))
+        const permissions = await this.getPermissions()
+        return permissions.find((p) => {
+            if (p.operation !== operation) { return false }
+
+            if (userId == null) {
+                return !!p.anonymous // match nullish userId against p.anonymous
+            }
+            return p.user.toLowerCase() === userIdCaseInsensitive // match against userId
+        })
     }
 
     grantPermission(operation, userId) {

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -52,7 +52,7 @@ export default class Stream {
         return permissions.find((p) => {
             if (p.operation !== operation) { return false }
 
-            if (userId === undefined) {
+            if (userIdCaseInsensitive === undefined) {
                 return !!p.anonymous // match nullish userId against p.anonymous
             }
             return p.user && p.user.toLowerCase() === userIdCaseInsensitive // match against userId
@@ -65,7 +65,7 @@ export default class Stream {
         }
         const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : undefined
 
-        if (userId != null) {
+        if (userIdCaseInsensitive !== undefined) {
             permissionObject.user = userIdCaseInsensitive
         } else {
             permissionObject.anonymous = true

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -247,7 +247,7 @@ describe('StreamrClient Connection', () => {
                 ])
                 done()
             })
-        })
+        }, 10000)
     })
 
     describe('ensureConnected', () => {


### PR DESCRIPTION
Ethers-generated address are in checkum-case (mixed case) https://docs.ethers.io/ethers.js/html/notes.html#checksum-address, but the backend seems to report addresses in lowercase format only.

This will break any `userId === address`  checks that don't lowercase the userId beforehand. 
CI for any existing PRs will be failing on this issue.

I changed the two places where I saw `userId` being used, there may be others with a different variable name. 

I haven't dug into why this issue has only just appeared, but perhaps it's related to the permissions changes @kare has been working on?
