### PR TITLE
Add streamr-client version in HTTP Headers

### DIFF
--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -32,7 +32,7 @@ import SubscribedStreamPartition from './SubscribedStreamPartition'
 import Stream from './rest/domain/Stream'
 import FailedToPublishError from './errors/FailedToPublishError'
 import MessageCreationUtil from './MessageCreationUtil'
-import { waitFor } from './utils'
+import { waitFor, getVersionString } from './utils'
 import RealTimeSubscription from './RealTimeSubscription'
 import CombinedSubscription from './CombinedSubscription'
 import Subscription from './Subscription'
@@ -92,6 +92,9 @@ export default class StreamrClient extends EventEmitter {
                 this.options.url = `${this.options.url}&messageLayerVersion=31`
             }
         }
+
+        // always add streamrClient version
+        this.options.url = `${this.options.url}&streamrClient=${getVersionString()}`
 
         // Backwards compatibility for option 'authKey' => 'apiKey'
         if (this.options.authKey && !this.options.apiKey) {

--- a/src/rest/DataUnionEndpoints.js
+++ b/src/rest/DataUnionEndpoints.js
@@ -21,7 +21,7 @@ import debugFactory from 'debug'
 
 import * as DataUnion from '../../contracts/DataUnion.json'
 
-import authFetch from './authFetch'
+import authFetch, { DEFAULT_HEADERS } from './authFetch'
 
 const { BigNumber, computeAddress, getAddress } = ethersUtils
 
@@ -51,9 +51,15 @@ function sleep(ms) {
     })
 }
 
-async function get(client, dataUnionContractAddress, endpoint, ...opts) {
+async function get(client, dataUnionContractAddress, endpoint, opts = {}) {
     const url = `${client.options.restUrl}/communities/${dataUnionContractAddress}${endpoint}`
-    const response = await fetch(url, ...opts)
+    const response = await fetch(url, {
+        ...opts,
+        headers: {
+            ...DEFAULT_HEADERS,
+            ...opts.headers,
+        },
+    })
     const json = await response.json()
     // server may return things like { code: "ConnectionPoolTimeoutException", message: "Timeout waiting for connection from pool" }
     //   they must still be handled as errors

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -2,6 +2,17 @@ import fetch from 'node-fetch'
 import debugFactory from 'debug'
 
 import AuthFetchError from '../errors/AuthFetchError'
+import pkg from '../../package.json'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+const STREAMR_CLIENT_USER_AGENT = `streamr-client-javascript/${pkg.version}${!isProduction ? 'dev' : ''}`
+
+export const DEFAULT_HEADERS = {
+    'User-Agent': global.navigator
+        ? `${global.navigator.userAgent} ${STREAMR_CLIENT_USER_AGENT}` // append to browser useragent
+        : `Node ${process.version} ${STREAMR_CLIENT_USER_AGENT}` // server user agent
+}
 
 const debug = debugFactory('StreamrClient:utils')
 
@@ -14,6 +25,7 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
             ...(session && !session.options.unauthenticated ? {
                 Authorization: `Bearer ${await session.getSessionToken(requireNewToken)}`,
             } : {}),
+            ...DEFAULT_HEADERS,
             ...opts.headers,
         },
     })

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -12,6 +12,7 @@ const debug = debugFactory('StreamrClient:utils')
 
 const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
     const options = {
+        ...opts,
         headers: {
             ...DEFAULT_HEADERS,
             ...opts.headers,

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -2,12 +2,10 @@ import fetch from 'node-fetch'
 import debugFactory from 'debug'
 
 import AuthFetchError from '../errors/AuthFetchError'
-import pkg from '../../package.json'
-
-const isProduction = process.env.NODE_ENV === 'production'
+import { getVersionString } from '../utils'
 
 export const DEFAULT_HEADERS = {
-    'Streamr-Client': `streamr-client-javascript/${pkg.version}${!isProduction ? 'dev' : ''}`
+    'Streamr-Client': `streamr-client-javascript/${getVersionString()}`
 }
 
 const debug = debugFactory('StreamrClient:utils')

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -6,12 +6,8 @@ import pkg from '../../package.json'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
-const STREAMR_CLIENT_USER_AGENT = `streamr-client-javascript/${pkg.version}${!isProduction ? 'dev' : ''}`
-
 export const DEFAULT_HEADERS = {
-    'User-Agent': global.navigator
-        ? `${global.navigator.userAgent} ${STREAMR_CLIENT_USER_AGENT}` // append to browser useragent
-        : `Node ${process.version} ${STREAMR_CLIENT_USER_AGENT}` // server user agent
+    'Streamr-Client': `streamr-client-javascript/${pkg.version}${!isProduction ? 'dev' : ''}`
 }
 
 const debug = debugFactory('StreamrClient:utils')

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -11,6 +11,13 @@ export const DEFAULT_HEADERS = {
 const debug = debugFactory('StreamrClient:utils')
 
 const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
+    const options = {
+        headers: {
+            ...DEFAULT_HEADERS,
+            ...opts.headers,
+        }
+    }
+
     debug('authFetch: ', url, opts)
 
     const response = await fetch(url, {
@@ -19,8 +26,7 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
             ...(session && !session.options.unauthenticated ? {
                 Authorization: `Bearer ${await session.getSessionToken(requireNewToken)}`,
             } : {}),
-            ...DEFAULT_HEADERS,
-            ...opts.headers,
+            ...options.headers,
         },
     })
 
@@ -33,7 +39,7 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
             throw new AuthFetchError(e.message, response, body)
         }
     } else if ([400, 401].includes(response.status) && !requireNewToken) {
-        return authFetch(url, session, opts, true)
+        return authFetch(url, session, options, true)
     } else {
         throw new AuthFetchError(`Request to ${url} returned with error code ${response.status}.`, response, body)
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,10 @@
+import pkg from '../package.json'
+
+export function getVersionString() {
+    const isProduction = process.env.NODE_ENV === 'production'
+    return `${pkg.version}${!isProduction ? 'dev' : ''}`
+}
+
 /**
  * Converts a .once event listener into a promise.
  * Rejects if an 'error' event is received before resolving.

--- a/test/integration/authFetch.test.js
+++ b/test/integration/authFetch.test.js
@@ -14,7 +14,7 @@ describe('authFetch', () => {
         await client.ensureDisconnected()
     })
 
-    it('sends user-agent header', async () => {
+    it('sends Streamr-Client header', async () => {
         client = new StreamrClient({
             auth: {
                 privateKey: ethers.Wallet.createRandom().privateKey,
@@ -29,7 +29,7 @@ describe('authFetch', () => {
             expect(typeof url).toEqual('string')
             expect(opts).toMatchObject({
                 headers: {
-                    'User-Agent': expect.stringMatching('streamr-client-javascript'),
+                    'Streamr-Client': expect.stringMatching('streamr-client-javascript'),
                 },
             })
         })

--- a/test/integration/authFetch.test.js
+++ b/test/integration/authFetch.test.js
@@ -1,0 +1,37 @@
+jest.mock('node-fetch', () => jest.fn(jest.requireActual('node-fetch')))
+
+import fetch from 'node-fetch'
+import { ethers } from 'ethers'
+
+import StreamrClient from '../../src'
+
+import config from './config'
+
+describe('authFetch', () => {
+    let client
+    afterEach(async () => {
+        if (!client) { return }
+        await client.ensureDisconnected()
+    })
+
+    it('sends user-agent header', async () => {
+        client = new StreamrClient({
+            auth: {
+                privateKey: ethers.Wallet.createRandom().privateKey,
+            },
+            autoConnect: false,
+            autoDisconnect: false,
+            ...config.clientOptions,
+        })
+        await client.connect()
+        expect(fetch).toHaveBeenCalled()
+        fetch.mock.calls.forEach(([url, opts]) => {
+            expect(typeof url).toEqual('string')
+            expect(opts).toMatchObject({
+                headers: {
+                    'User-Agent': expect.stringMatching('streamr-client-javascript'),
+                },
+            })
+        })
+    })
+})

--- a/test/unit/KeyExchangeUtil.test.js
+++ b/test/unit/KeyExchangeUtil.test.js
@@ -46,7 +46,7 @@ describe('KeyExchangeUtil', () => {
     beforeEach(async () => {
         client = await setupClient()
         util = new KeyExchangeUtil(client)
-    })
+    }, 20000)
     describe('getSubscribers', () => {
         it('should use endpoint to retrieve subscribers', async () => {
             const retrievedSubscribers = await util.getSubscribers('streamId')


### PR DESCRIPTION
Adds header like so for server:
```
'User-Agent': 'Node v10.19.0 streamr-client-javascript/3.2.0dev'
```

`dev` only added if requests sent via non-npm-installed version of streamr-client.

Didn't append the `node-fetch` header that's currently sent because node-fetch doesn't expose it for extension, can only replace. This seems fine.

Client currently doesn't run in the browser (3.2.0), so haven't yet tested browser incantation, but intention is to append same `streamr-client-javascript/3.2.0dev` string to existing `navigator.userAgent`.