### PR TITLE
Make EncryptionUtil Browser Compatible

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,6 +38,9 @@ jobs:
     - name: test-unit
       run: npm run test-unit
 
+    - name: test-build
+      run: npm run build && npm run build-example
+
     - name: test-integration
       run: |
         sudo service mysql stop
@@ -46,5 +49,3 @@ jobs:
         ${GITHUB_WORKSPACE}/streamr-docker-dev/streamr-docker-dev/bin.sh start --wait
         npm run test-integration
 
-    - name: test-build
-      run: npm run build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,7 +39,7 @@ jobs:
       run: npm run test-unit
 
     - name: test-build
-      run: npm run build && npm run build-example
+      run: npm run build && npm run install-example && npm run build-example
 
     - name: test-integration
       run: |

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -4,7 +4,8 @@
   "description": "Example of how streamr-client can be included in webpack projects",
   "scripts": {
     "build": "NODE_ENV=production webpack --mode=production --progress",
-    "dev": "webpack --progress --colors --watch"
+    "dev": "webpack --progress --colors --watch",
+    "build-with-parent": "npm ci && cp -Rpfv ../../dist ./node_modules/streamr-client/ && rm node_modules/streamr-client/package.json; cp ../../package.json ./node_modules/streamr-client/package.json && npm run build"
   },
   "engines": {
     "node": ">= 8"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "NODE_ENV=production webpack --mode=production --progress",
     "dev": "webpack --progress --colors --watch",
-    "build-with-parent": "npm ci && cp -Rpfv ../../dist ./node_modules/streamr-client/ && rm node_modules/streamr-client/package.json; cp ../../package.json ./node_modules/streamr-client/package.json && npm run build"
+    "build-with-parent": "cp -Rpfv ../../dist ./node_modules/streamr-client/ && rm node_modules/streamr-client/package.json; cp ../../package.json ./node_modules/streamr-client/package.json && npm run build"
   },
   "engines": {
     "node": ">= 8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7523,7 +7523,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.1",
@@ -7604,6 +7605,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -7819,22 +7821,27 @@
       }
     },
     "node-webcrypto-ossl": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.48.tgz",
-      "integrity": "sha512-MWUkQ/5wrs7lpAr+fhsLMfjdxKGd3dQFVqWbNMkyYyCMRW8E7ScailqtCZYDLTnJtU6B+91rXxCJNyZvbYaSOg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-2.0.1.tgz",
+      "integrity": "sha512-ZUrA7mSNtwMOJGLnqoCbVM6huN0PAdtdB6pTeeycDp3rwET29q+xbUzbazrWpTO8Xli+twqLkExDi9B6gDnn7A==",
       "requires": {
-        "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "tslib": "^1.9.3",
-        "webcrypto-core": "^0.1.26"
-      }
-    },
-    "node-webcrypto-shim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-shim/-/node-webcrypto-shim-0.0.1.tgz",
-      "integrity": "sha512-8MBE1nDPpJ5IMM48K98EZ6UZavN/Y3P2SKkmux9Pr8RkQNCy3ahVOayjSE8g6/EGpN5w6nT+Vj9RvZ8iXY6HxQ==",
-      "requires": {
-        "node-webcrypto-ossl": "^1.0.31"
+        "mkdirp": "^1.0.3",
+        "nan": "^2.14.0",
+        "pvtsutils": "^1.0.10",
+        "tslib": "^1.11.1",
+        "webcrypto-core": "^1.0.18"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+        },
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+        }
       }
     },
     "normalize-package-data": {
@@ -8572,6 +8579,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "pvtsutils": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
+      "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
     },
     "qs": {
       "version": "6.9.1",
@@ -10825,11 +10840,19 @@
       }
     },
     "webcrypto-core": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.26.tgz",
-      "integrity": "sha512-BZVgJZkkHyuz8loKvsaOKiBDXDpmMZf5xG4QAOlSeYdXlFUl9c1FRrVnAXcOdb4fTHMG+TRu81odJwwSfKnWTA==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.18.tgz",
+      "integrity": "sha512-wHRMXYxtDUWsTXNyRdaYlbcbq1OJF9pQov5THqvn5OBvixpCjnjU2spvEscxqRY8bLlpHk2S7RtROIMyNoEyFg==",
       "requires": {
-        "tslib": "^1.7.1"
+        "pvtsutils": "^1.0.10",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+        }
       }
     },
     "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7523,8 +7523,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
       "version": "3.1.1",
@@ -7605,7 +7604,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -7638,9 +7636,7 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7820,6 +7816,25 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
+      }
+    },
+    "node-webcrypto-ossl": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.48.tgz",
+      "integrity": "sha512-MWUkQ/5wrs7lpAr+fhsLMfjdxKGd3dQFVqWbNMkyYyCMRW8E7ScailqtCZYDLTnJtU6B+91rXxCJNyZvbYaSOg==",
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "tslib": "^1.9.3",
+        "webcrypto-core": "^0.1.26"
+      }
+    },
+    "node-webcrypto-shim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-webcrypto-shim/-/node-webcrypto-shim-0.0.1.tgz",
+      "integrity": "sha512-8MBE1nDPpJ5IMM48K98EZ6UZavN/Y3P2SKkmux9Pr8RkQNCy3ahVOayjSE8g6/EGpN5w6nT+Vj9RvZ8iXY6HxQ==",
+      "requires": {
+        "node-webcrypto-ossl": "^1.0.31"
       }
     },
     "normalize-package-data": {
@@ -10448,8 +10463,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -10808,6 +10822,14 @@
         "chokidar": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
+      }
+    },
+    "webcrypto-core": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.26.tgz",
+      "integrity": "sha512-BZVgJZkkHyuz8loKvsaOKiBDXDpmMZf5xG4QAOlSeYdXlFUl9c1FRrVnAXcOdb4fTHMG+TRu81odJwwSfKnWTA==",
+      "requires": {
+        "tslib": "^1.7.1"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "jest --detectOpenHandles",
     "test-unit": "jest test/unit --detectOpenHandles",
     "coverage": "jest --coverage",
-    "test-integration": "jest test/integration --detectOpenHandles"
+    "test-integration": "jest test/integration --detectOpenHandles",
+    "build-example": "cd examples/webpack && npm run build-with-parent"
   },
   "engines": {
     "node": ">= 10"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git://github.com/streamr-dev/streamr-client.git"
   },
   "main": "dist/streamr-client.js",
+  "browser": "dist/streamr-client.web.min.js",
   "directories": {
     "test": "test"
   },
@@ -19,12 +20,6 @@
     "test-unit": "jest test/unit --detectOpenHandles",
     "coverage": "jest --coverage",
     "test-integration": "jest test/integration --detectOpenHandles"
-  },
-  "browser": {
-    "http": "./src/shim/http-https.js",
-    "https": "./src/shim/http-https.js",
-    "ws": "./src/shim/ws.js",
-    "node-fetch": "./src/shim/node-fetch.js"
   },
   "engines": {
     "node": ">= 10"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "heap": "^0.2.6",
     "lodash.uniqueid": "^4.0.1",
     "node-fetch": "^2.6.0",
+    "node-webcrypto-shim": "0.0.1",
     "once": "^1.4.0",
     "qs": "^6.9.1",
     "randomstring": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test-unit": "jest test/unit --detectOpenHandles",
     "coverage": "jest --coverage",
     "test-integration": "jest test/integration --detectOpenHandles",
+    "install-example": "cd examples/webpack && npm ci",
     "build-example": "cd examples/webpack && npm run build-with-parent"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "heap": "^0.2.6",
     "lodash.uniqueid": "^4.0.1",
     "node-fetch": "^2.6.0",
-    "node-webcrypto-shim": "0.0.1",
+    "node-webcrypto-ossl": "^2.0.1",
     "once": "^1.4.0",
     "qs": "^6.9.1",
     "randomstring": "^1.1.5",

--- a/src/EncryptionUtil.js
+++ b/src/EncryptionUtil.js
@@ -1,7 +1,8 @@
 import crypto from 'crypto'
 import util from 'util'
 
-import WebCrypto from 'node-webcrypto-shim' // this allows us to run tests in node against browser API
+// this is shimmed out for actual browser build allows us to run tests in node against browser API
+import WebCrypto from 'node-webcrypto-ossl'
 import { ethers } from 'ethers'
 import { MessageLayer } from 'streamr-client-protocol'
 

--- a/src/EncryptionUtil.js
+++ b/src/EncryptionUtil.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto'
 import util from 'util'
 
-import WebCrypto from 'node-webcrypto-shim'
+import WebCrypto from 'node-webcrypto-shim' // this allows us to run tests in node against browser API
 import { ethers } from 'ethers'
 import { MessageLayer } from 'streamr-client-protocol'
 

--- a/src/EncryptionUtil.js
+++ b/src/EncryptionUtil.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import util from 'util'
 
+import WebCrypto from 'node-webcrypto-shim'
 import { ethers } from 'ethers'
 import { MessageLayer } from 'streamr-client-protocol'
 
@@ -15,11 +16,11 @@ function ab2str(buf) {
 
 async function exportCryptoKey(key, { isPrivate = false } = {}) {
     const keyType = isPrivate ? 'pkcs8' : 'spki'
-    const exported = await global.crypto.subtle.exportKey(keyType, key)
+    const exported = await WebCrypto.subtle.exportKey(keyType, key)
     const exportedAsString = ab2str(exported)
     const exportedAsBase64 = global.btoa(exportedAsString)
     const TYPE = isPrivate ? 'PRIVATE' : 'PUBLIC'
-    return `-----BEGIN ${TYPE} KEY-----\n${exportedAsBase64}\n-----END ${TYPE} KEY-----`
+    return `-----BEGIN ${TYPE} KEY-----\n${exportedAsBase64}\n-----END ${TYPE} KEY-----\n`
 }
 
 export default class EncryptionUtil {
@@ -182,7 +183,7 @@ export default class EncryptionUtil {
     }
 
     async _keyPairBrowser() {
-        const { publicKey, privateKey } = await global.crypto.subtle.generateKey({
+        const { publicKey, privateKey } = await WebCrypto.subtle.generateKey({
             name: 'RSA-OAEP',
             modulusLength: 4096,
             publicExponent: new Uint8Array([1, 0, 1]), // 65537

--- a/src/EncryptionUtil.js
+++ b/src/EncryptionUtil.js
@@ -148,11 +148,12 @@ export default class EncryptionUtil {
     }
 
     async __generateKeyPair() {
-        if (process.isBrowser) { return this._keyPairBrowser() }
+        if (process.browser) { return this._keyPairBrowser() }
         return this._keyPairServer()
     }
 
     async _keyPairServer() {
+        const generateKeyPair = util.promisify(crypto.generateKeyPair)
         const { publicKey, privateKey } = await generateKeyPair('rsa', {
             modulusLength: 4096,
             publicKeyEncoding: {

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -569,6 +569,7 @@ export default class StreamrClient extends EventEmitter {
         })
         sub.on('groupKeyMissing', async (publisherId, start, end) => {
             if (this.encryptionUtil) {
+                await this.encryptionUtil.onReady()
                 const streamMessage = await this.msgCreationUtil.createGroupKeyRequest(
                     publisherId, sub.streamId, this.encryptionUtil.getPublicKey(), start, end,
                 )

--- a/src/shim/crypto.js
+++ b/src/shim/crypto.js
@@ -1,0 +1,1 @@
+module.exports = window.crypto

--- a/src/shim/crypto.js
+++ b/src/shim/crypto.js
@@ -1,1 +1,3 @@
-module.exports = window.crypto
+module.exports = function() {
+    return window.crypto
+}

--- a/src/shim/crypto.js
+++ b/src/shim/crypto.js
@@ -1,3 +1,3 @@
-module.exports = function() {
+exports.Crypto = function() {
     return window.crypto
 }

--- a/test/unit/EncryptionUtil.test.js
+++ b/test/unit/EncryptionUtil.test.js
@@ -9,14 +9,16 @@ import EncryptionUtil from '../../src/EncryptionUtil'
 const { StreamMessage } = MessageLayer
 
 describe('EncryptionUtil', () => {
-    it('rsa decryption after encryption equals the initial plaintext', () => {
+    it('rsa decryption after encryption equals the initial plaintext', async () => {
         const encryptionUtil = new EncryptionUtil()
+        await encryptionUtil.onReady()
         const plaintext = 'some random text'
         const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), encryptionUtil.getPublicKey())
         expect(encryptionUtil.decryptWithPrivateKey(ciphertext).toString('utf8')).toStrictEqual(plaintext)
     })
-    it('rsa decryption after encryption equals the initial plaintext (hex strings)', () => {
+    it('rsa decryption after encryption equals the initial plaintext (hex strings)', async () => {
         const encryptionUtil = new EncryptionUtil()
+        await encryptionUtil.onReady()
         const plaintext = 'some random text'
         const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), encryptionUtil.getPublicKey(), true)
         expect(encryptionUtil.decryptWithPrivateKey(ciphertext, true).toString('utf8')).toStrictEqual(plaintext)

--- a/test/unit/EncryptionUtil.test.js
+++ b/test/unit/EncryptionUtil.test.js
@@ -8,14 +8,18 @@ import EncryptionUtil from '../../src/EncryptionUtil'
 
 const { StreamMessage } = MessageLayer
 
+// wrap these tests so can run same tests as if in browser
 function TestEncryptionUtil({ isBrowser = false } = {}) {
-    describe('EncryptionUtil', () => {
+    describe(`EncryptionUtil ${isBrowser ? 'Browser' : 'Server'}`, () => {
         beforeAll(() => {
+            // this is the toggle used in EncryptionUtil to
+            // use the webcrypto apis
             process.browser = !!isBrowser
         })
         afterAll(() => {
             process.browser = !isBrowser
         })
+
         it('rsa decryption after encryption equals the initial plaintext', async () => {
             const encryptionUtil = new EncryptionUtil()
             await encryptionUtil.onReady()
@@ -180,5 +184,10 @@ function TestEncryptionUtil({ isBrowser = false } = {}) {
     })
 }
 
-TestEncryptionUtil({ isBrowser: false })
-TestEncryptionUtil({ isBrowser: true })
+TestEncryptionUtil({
+    isBrowser: false,
+})
+
+TestEncryptionUtil({
+    isBrowser: true,
+})

--- a/test/unit/EncryptionUtil.test.js
+++ b/test/unit/EncryptionUtil.test.js
@@ -8,166 +8,177 @@ import EncryptionUtil from '../../src/EncryptionUtil'
 
 const { StreamMessage } = MessageLayer
 
-describe('EncryptionUtil', () => {
-    it('rsa decryption after encryption equals the initial plaintext', async () => {
-        const encryptionUtil = new EncryptionUtil()
-        await encryptionUtil.onReady()
-        const plaintext = 'some random text'
-        const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), encryptionUtil.getPublicKey())
-        expect(encryptionUtil.decryptWithPrivateKey(ciphertext).toString('utf8')).toStrictEqual(plaintext)
-    })
-    it('rsa decryption after encryption equals the initial plaintext (hex strings)', async () => {
-        const encryptionUtil = new EncryptionUtil()
-        await encryptionUtil.onReady()
-        const plaintext = 'some random text'
-        const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), encryptionUtil.getPublicKey(), true)
-        expect(encryptionUtil.decryptWithPrivateKey(ciphertext, true).toString('utf8')).toStrictEqual(plaintext)
-    })
-    it('aes decryption after encryption equals the initial plaintext', () => {
-        const key = crypto.randomBytes(32)
-        const plaintext = 'some random text'
-        const ciphertext = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
-        expect(EncryptionUtil.decrypt(ciphertext, key).toString('utf8')).toStrictEqual(plaintext)
-    })
-    it('aes encryption preserves size (plus iv)', () => {
-        const key = crypto.randomBytes(32)
-        const plaintext = 'some random text'
-        const plaintextBuffer = Buffer.from(plaintext, 'utf8')
-        const ciphertext = EncryptionUtil.encrypt(plaintextBuffer, key)
-        const ciphertextBuffer = ethers.utils.arrayify(`0x${ciphertext}`)
-        expect(ciphertextBuffer.length).toStrictEqual(plaintextBuffer.length + 16)
-    })
-    it('multiple same encrypt() calls use different ivs and produce different ciphertexts', () => {
-        const key = crypto.randomBytes(32)
-        const plaintext = 'some random text'
-        const ciphertext1 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
-        const ciphertext2 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
-        expect(ciphertext1.slice(0, 32)).not.toStrictEqual(ciphertext2.slice(0, 32))
-        expect(ciphertext1.slice(32)).not.toStrictEqual(ciphertext2.slice(32))
-    })
-    it('StreamMessage gets encrypted', () => {
-        const key = crypto.randomBytes(32)
-        const streamMessage = StreamMessage.create(
-            ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
-            StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
-                foo: 'bar'
-            }, StreamMessage.SIGNATURE_TYPES.NONE, null,
-        )
-        EncryptionUtil.encryptStreamMessage(streamMessage, key)
-        expect(streamMessage.getSerializedContent()).not.toStrictEqual('{"foo":"bar"}')
-        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.AES)
-    })
-    it('StreamMessage decryption after encryption equals the initial StreamMessage', () => {
-        const key = crypto.randomBytes(32)
-        const streamMessage = StreamMessage.create(
-            ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
-            StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
-                foo: 'bar'
-            }, StreamMessage.SIGNATURE_TYPES.NONE, null,
-        )
-        EncryptionUtil.encryptStreamMessage(streamMessage, key)
-        const newKey = EncryptionUtil.decryptStreamMessage(streamMessage, key)
-        expect(newKey).toBe(null)
-        expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
-        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
-    })
-    it('StreamMessage gets encrypted with new key', () => {
-        const key = crypto.randomBytes(32)
-        const newKey = crypto.randomBytes(32)
-        const streamMessage = StreamMessage.create(
-            ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
-            StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
-                foo: 'bar'
-            }, StreamMessage.SIGNATURE_TYPES.NONE, null,
-        )
-        EncryptionUtil.encryptStreamMessageAndNewKey(newKey, streamMessage, key)
-        expect(streamMessage.getSerializedContent()).not.toStrictEqual('{"foo":"bar"}')
-        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NEW_KEY_AND_AES)
-    })
-    it('StreamMessage decryption after encryption equals the initial StreamMessage (with new key)', () => {
-        const key = crypto.randomBytes(32)
-        const newKey = crypto.randomBytes(32)
-        const streamMessage = StreamMessage.create(
-            ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
-            StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
-                foo: 'bar'
-            }, StreamMessage.SIGNATURE_TYPES.NONE, null,
-        )
-        EncryptionUtil.encryptStreamMessageAndNewKey(newKey, streamMessage, key)
-        const newKeyReceived = EncryptionUtil.decryptStreamMessage(streamMessage, key)
-        expect(newKeyReceived).toStrictEqual(newKey)
-        expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
-        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
-    })
-    it('throws if invalid public key passed in the constructor', () => {
-        const keys = crypto.generateKeyPairSync('rsa', {
-            modulusLength: 4096,
-            publicKeyEncoding: {
-                type: 'spki',
-                format: 'pem',
-            },
-            privateKeyEncoding: {
-                type: 'pkcs8',
-                format: 'pem',
-            },
+function TestEncryptionUtil({ isBrowser = false } = {}) {
+    describe('EncryptionUtil', () => {
+        beforeAll(() => {
+            process.browser = !!isBrowser
         })
-        assert.throws(() => {
+        afterAll(() => {
+            process.browser = !isBrowser
+        })
+        it('rsa decryption after encryption equals the initial plaintext', async () => {
+            const encryptionUtil = new EncryptionUtil()
+            await encryptionUtil.onReady()
+            const plaintext = 'some random text'
+            const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), encryptionUtil.getPublicKey())
+            expect(encryptionUtil.decryptWithPrivateKey(ciphertext).toString('utf8')).toStrictEqual(plaintext)
+        })
+        it('rsa decryption after encryption equals the initial plaintext (hex strings)', async () => {
+            const encryptionUtil = new EncryptionUtil()
+            await encryptionUtil.onReady()
+            const plaintext = 'some random text'
+            const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), encryptionUtil.getPublicKey(), true)
+            expect(encryptionUtil.decryptWithPrivateKey(ciphertext, true).toString('utf8')).toStrictEqual(plaintext)
+        })
+        it('aes decryption after encryption equals the initial plaintext', () => {
+            const key = crypto.randomBytes(32)
+            const plaintext = 'some random text'
+            const ciphertext = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+            expect(EncryptionUtil.decrypt(ciphertext, key).toString('utf8')).toStrictEqual(plaintext)
+        })
+        it('aes encryption preserves size (plus iv)', () => {
+            const key = crypto.randomBytes(32)
+            const plaintext = 'some random text'
+            const plaintextBuffer = Buffer.from(plaintext, 'utf8')
+            const ciphertext = EncryptionUtil.encrypt(plaintextBuffer, key)
+            const ciphertextBuffer = ethers.utils.arrayify(`0x${ciphertext}`)
+            expect(ciphertextBuffer.length).toStrictEqual(plaintextBuffer.length + 16)
+        })
+        it('multiple same encrypt() calls use different ivs and produce different ciphertexts', () => {
+            const key = crypto.randomBytes(32)
+            const plaintext = 'some random text'
+            const ciphertext1 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+            const ciphertext2 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+            expect(ciphertext1.slice(0, 32)).not.toStrictEqual(ciphertext2.slice(0, 32))
+            expect(ciphertext1.slice(32)).not.toStrictEqual(ciphertext2.slice(32))
+        })
+        it('StreamMessage gets encrypted', () => {
+            const key = crypto.randomBytes(32)
+            const streamMessage = StreamMessage.create(
+                ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
+                StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
+                    foo: 'bar'
+                }, StreamMessage.SIGNATURE_TYPES.NONE, null,
+            )
+            EncryptionUtil.encryptStreamMessage(streamMessage, key)
+            expect(streamMessage.getSerializedContent()).not.toStrictEqual('{"foo":"bar"}')
+            expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.AES)
+        })
+        it('StreamMessage decryption after encryption equals the initial StreamMessage', () => {
+            const key = crypto.randomBytes(32)
+            const streamMessage = StreamMessage.create(
+                ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
+                StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
+                    foo: 'bar'
+                }, StreamMessage.SIGNATURE_TYPES.NONE, null,
+            )
+            EncryptionUtil.encryptStreamMessage(streamMessage, key)
+            const newKey = EncryptionUtil.decryptStreamMessage(streamMessage, key)
+            expect(newKey).toBe(null)
+            expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
+            expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
+        })
+        it('StreamMessage gets encrypted with new key', () => {
+            const key = crypto.randomBytes(32)
+            const newKey = crypto.randomBytes(32)
+            const streamMessage = StreamMessage.create(
+                ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
+                StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
+                    foo: 'bar'
+                }, StreamMessage.SIGNATURE_TYPES.NONE, null,
+            )
+            EncryptionUtil.encryptStreamMessageAndNewKey(newKey, streamMessage, key)
+            expect(streamMessage.getSerializedContent()).not.toStrictEqual('{"foo":"bar"}')
+            expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NEW_KEY_AND_AES)
+        })
+        it('StreamMessage decryption after encryption equals the initial StreamMessage (with new key)', () => {
+            const key = crypto.randomBytes(32)
+            const newKey = crypto.randomBytes(32)
+            const streamMessage = StreamMessage.create(
+                ['streamId', 0, 1, 0, 'publisherId', 'msgChainId'], null,
+                StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, {
+                    foo: 'bar'
+                }, StreamMessage.SIGNATURE_TYPES.NONE, null,
+            )
+            EncryptionUtil.encryptStreamMessageAndNewKey(newKey, streamMessage, key)
+            const newKeyReceived = EncryptionUtil.decryptStreamMessage(streamMessage, key)
+            expect(newKeyReceived).toStrictEqual(newKey)
+            expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
+            expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
+        })
+        it('throws if invalid public key passed in the constructor', () => {
+            const keys = crypto.generateKeyPairSync('rsa', {
+                modulusLength: 4096,
+                publicKeyEncoding: {
+                    type: 'spki',
+                    format: 'pem',
+                },
+                privateKeyEncoding: {
+                    type: 'pkcs8',
+                    format: 'pem',
+                },
+            })
+            assert.throws(() => {
+                // eslint-disable-next-line no-new
+                new EncryptionUtil({
+                    privateKey: keys.privateKey,
+                    publicKey: 'wrong public key',
+                })
+            }, /Error: "publicKey" must be a PKCS#8 RSA public key as a string in the PEM format/)
+        })
+        it('throws if invalid private key passed in the constructor', () => {
+            const keys = crypto.generateKeyPairSync('rsa', {
+                modulusLength: 4096,
+                publicKeyEncoding: {
+                    type: 'spki',
+                    format: 'pem',
+                },
+                privateKeyEncoding: {
+                    type: 'pkcs8',
+                    format: 'pem',
+                },
+            })
+            assert.throws(() => {
+                // eslint-disable-next-line no-new
+                new EncryptionUtil({
+                    privateKey: 'wrong private key',
+                    publicKey: keys.publicKey,
+                })
+            }, /Error: "privateKey" must be a PKCS#8 RSA public key as a string in the PEM format/)
+        })
+        it('does not throw if valid key pair passed in the constructor', () => {
+            const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+                modulusLength: 4096,
+                publicKeyEncoding: {
+                    type: 'spki',
+                    format: 'pem',
+                },
+                privateKeyEncoding: {
+                    type: 'pkcs8',
+                    format: 'pem',
+                },
+            })
             // eslint-disable-next-line no-new
             new EncryptionUtil({
-                privateKey: keys.privateKey,
-                publicKey: 'wrong public key',
+                privateKey,
+                publicKey,
             })
-        }, /Error: "publicKey" must be a PKCS#8 RSA public key as a string in the PEM format/)
-    })
-    it('throws if invalid private key passed in the constructor', () => {
-        const keys = crypto.generateKeyPairSync('rsa', {
-            modulusLength: 4096,
-            publicKeyEncoding: {
-                type: 'spki',
-                format: 'pem',
-            },
-            privateKeyEncoding: {
-                type: 'pkcs8',
-                format: 'pem',
-            },
         })
-        assert.throws(() => {
-            // eslint-disable-next-line no-new
-            new EncryptionUtil({
-                privateKey: 'wrong private key',
-                publicKey: keys.publicKey,
-            })
-        }, /Error: "privateKey" must be a PKCS#8 RSA public key as a string in the PEM format/)
-    })
-    it('does not throw if valid key pair passed in the constructor', () => {
-        const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
-            modulusLength: 4096,
-            publicKeyEncoding: {
-                type: 'spki',
-                format: 'pem',
-            },
-            privateKeyEncoding: {
-                type: 'pkcs8',
-                format: 'pem',
-            },
+        it('validateGroupKey() throws if key is the wrong size', () => {
+            assert.throws(() => {
+                EncryptionUtil.validateGroupKey(crypto.randomBytes(16))
+            }, /Error: Group key must have a size of 256 bits/)
         })
-        // eslint-disable-next-line no-new
-        new EncryptionUtil({
-            privateKey,
-            publicKey,
+        it('validateGroupKey() throws if key is not a buffer', () => {
+            assert.throws(() => {
+                EncryptionUtil.validateGroupKey(ethers.utils.hexlify(crypto.randomBytes(32)))
+            }, /Error: Group key must be a Buffer/)
+        })
+        it('validateGroupKey() does not throw', () => {
+            EncryptionUtil.validateGroupKey(crypto.randomBytes(32))
         })
     })
-    it('validateGroupKey() throws if key is the wrong size', () => {
-        assert.throws(() => {
-            EncryptionUtil.validateGroupKey(crypto.randomBytes(16))
-        }, /Error: Group key must have a size of 256 bits/)
-    })
-    it('validateGroupKey() throws if key is not a buffer', () => {
-        assert.throws(() => {
-            EncryptionUtil.validateGroupKey(ethers.utils.hexlify(crypto.randomBytes(32)))
-        }, /Error: Group key must be a Buffer/)
-    })
-    it('validateGroupKey() does not throw', () => {
-        EncryptionUtil.validateGroupKey(crypto.randomBytes(32))
-    })
-})
+}
+
+TestEncryptionUtil({ isBrowser: false })
+TestEncryptionUtil({ isBrowser: true })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,15 @@ const clientConfig = merge({}, commonConfig, {
         libraryTarget: 'umd2',
         filename: libraryName + '.web.js',
     },
+    resolve: {
+        alias: {
+            http: path.resolve(__dirname, './src/shim/http-https.js'),
+            https: path.resolve(__dirname, './src/shim/http-https.js'),
+            ws: path.resolve(__dirname, './src/shim/ws.js'),
+            'node-fetch': path.resolve(__dirname, './src/shim/node-fetch.js'),
+            'node-webcrypto-ossl': path.resolve(__dirname, 'src/shim/crypto.js'),
+        }
+    }
 })
 
 let clientMinifiedConfig = {}


### PR DESCRIPTION
Current version of `streamr-client` (3.2.0) does not work in the browser because `crypto-browserify`, which is used by webpack to shim nodes `crypto` module in the browser, doesn't implement the `generateKeyPairSync` function, or even the async `generateKeyPair`.

I have added a possibly browser-compatible implementation of `_generateKeyPair` using https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey. 

Until we set up a system for running in-browser tests, I am not sure this actually works yet.

The browser API does not provide a sync version, so I've made both versions async and added some handling to ensure it doesn't enqueue the same work twice. The async version should be used in node anyway since keygen is expensive and we don't want to block unnecessarily while it happens.

An alternative could be to use a JS implementation like https://www.npmjs.com/package/keypair, however:

> Performance greatly depends on the bit size of the generated private key. With 1024 bits you get a key in 0.5s-2s, with 2048 bits it takes 8s-20s, on the same machine. As this will block the event loop while generating the key, make sure that's ok or to spawn a child process or run it inside a webworker.

We're using a 4096 bit key and on my machine that takes 26 seconds to generate. So a pure JS version is not a viable option for the browser without involving the complexity of adding web workers, the calls become async with this option too. We should probably be using the native crypto apis.

The browser crypto APIs have another caveat though: they are only available in secure contexts (i.e. HTTPS). So the streamr-client won't be able to generate keys on any non-https page.  We should probably fail gracefully when this situation is encountered e.g. toggle on `window.isSecureContext`. 
Note it does *appear* to work with `localhost` or `127.0.0.1`, but will fail when deployed or accessed via a different hostname.

----

update: So rather than booting a browser and testing that way, I've set it up to use a webcrypto polyfill that works in node so the tests can run. This is a lot simpler and probably gives us most of the confidence of running it in a real browser. Also added a test step that confirms that the built client lib code can actually be used in another webpack build e.g. no unresolvable deps etc.