### PR TITLE
CORE-1833: Changes needed to support permission refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Name | Description
 update() | Updates the properties of this Stream object by sending them to the API.
 delete() | Deletes this Stream.
 getPermissions() | Returns the list of permissions for this Stream.
-hasPermission(operation, user) | Returns a permission object, or null if no such permission was found. `operation` is one of 'read', 'write', or 'share'. `user` is the username of a user, or null for public permissions.
+hasPermission(operation, user) | Returns a permission object, or null if no such permission was found. Valid `operation` values for streams are: stream_get, stream_edit, stream_delete, stream_publish, stream_subscribe, and stream_share. `user` is the username of a user, or null for public permissions.
 grantPermission(operation, user) | Grants the permission to do `operation` to `user`, which are defined as above.
 revokePermission(permissionId) | Revokes a permission identified by its `id`.
 detectFields() | Updates the Stream field config (schema) to match the latest data point in the Stream.

--- a/src/rest/DataUnionEndpoints.js
+++ b/src/rest/DataUnionEndpoints.js
@@ -144,10 +144,16 @@ export async function deployDataUnion(options) {
         name: `Join-Part-${wallet.address.slice(0, 10)}-${Date.now()}`
     })
     debug(`Stream created: ${JSON.stringify(stream.toObject())}`)
-    const res1 = await stream.grantPermission('read', null)
-    debug(`Grant read permission response from server: ${JSON.stringify(res1)}`)
-    const res2 = await stream.grantPermission('write', streamrNodeAddress)
-    debug(`Grant write permission response to ${streamrNodeAddress} from server: ${JSON.stringify(res2)}`)
+
+    let res
+    res = await stream.grantPermission('stream_get', null)
+    debug(`Grant stream_get permission response from server: ${JSON.stringify(res)}`)
+    res = await stream.grantPermission('stream_subscribe', null)
+    debug(`Grant stream_subscribe permission response from server: ${JSON.stringify(res)}`)
+    res = await stream.grantPermission('stream_get', streamrNodeAddress)
+    debug(`Grant stream_get permission response to ${streamrNodeAddress} from server: ${JSON.stringify(res)}`)
+    res = await stream.grantPermission('stream_publish', streamrNodeAddress)
+    debug(`Grant stream_publish permission response to ${streamrNodeAddress} from server: ${JSON.stringify(res)}`)
 
     const deployer = new ContractFactory(DataUnion.abi, DataUnion.bytecode, wallet)
     const result = await deployer.deploy(streamrOperatorAddress, stream.id, tokenAddress, blockFreezePeriodSeconds, adminFeeBN)

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -6,7 +6,6 @@ import { getVersionString } from '../utils'
 
 export const DEFAULT_HEADERS = {
     'Streamr-Client': `streamr-client-javascript/${getVersionString()}`,
-    'Content-Type': 'application/json',
 }
 
 const debug = debugFactory('StreamrClient:utils')
@@ -18,6 +17,10 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
             ...DEFAULT_HEADERS,
             ...opts.headers,
         }
+    }
+    // add default 'Content-Type: application/json' header for requests with a body
+    if (options.body != null && !options.headers['Content-Type']) {
+        options.headers['Content-Type'] = 'application/json'
     }
 
     debug('authFetch: ', url, opts)

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -5,7 +5,8 @@ import AuthFetchError from '../errors/AuthFetchError'
 import { getVersionString } from '../utils'
 
 export const DEFAULT_HEADERS = {
-    'Streamr-Client': `streamr-client-javascript/${getVersionString()}`
+    'Streamr-Client': `streamr-client-javascript/${getVersionString()}`,
+    'Content-Type': 'application/json',
 }
 
 const debug = debugFactory('StreamrClient:utils')

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -151,22 +151,22 @@ describe('StreamEndpoints', () => {
     describe('Stream permissions', () => {
         it('Stream.getPermissions', async () => {
             const permissions = await createdStream.getPermissions()
-            assert.equal(permissions.length, 3) // read, write, share for the owner
+            assert.equal(permissions.length, 6, `Unexpected number of permissions: ${JSON.stringify(permissions)}`) // get, edit, delete, subscribe, publish, share
         })
 
         it('Stream.hasPermission', async () => {
-            assert(await createdStream.hasPermission('share', wallet.address))
+            assert(await createdStream.hasPermission('stream_share', wallet.address))
         })
 
         it('Stream.grantPermission', async () => {
-            await createdStream.grantPermission('read', null) // public read
-            assert(await createdStream.hasPermission('read', null))
+            await createdStream.grantPermission('stream_subscribe', null) // public read
+            assert(await createdStream.hasPermission('stream_subscribe', null))
         })
 
         it('Stream.revokePermission', async () => {
-            const publicRead = await createdStream.hasPermission('read', null)
+            const publicRead = await createdStream.hasPermission('stream_subscribe', null)
             await createdStream.revokePermission(publicRead.id)
-            assert(!(await createdStream.hasPermission('read', null)))
+            assert(!(await createdStream.hasPermission('stream_subscribe', null)))
         })
     })
 

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert'
 
 import { ethers } from 'ethers'
+import { wait } from 'streamr-test-utils'
 
 import StreamrClient from '../../src'
 
@@ -33,34 +34,33 @@ describe('StreamEndpoints', () => {
     })
 
     describe('Stream creation', () => {
-        it('createStream', () => client.createStream({
-            name,
-            requireSignedData: true,
-            requireEncryptedData: false,
-        }).then((stream) => {
+        it('createStream', async () => {
+            const stream = await client.createStream({
+                name,
+                requireSignedData: true,
+                requireEncryptedData: false,
+            })
             createdStream = stream
             assert(createdStream.id)
             assert.equal(createdStream.name, name)
             assert.strictEqual(createdStream.requireSignedData, true)
-        }).catch((err) => { throw err }))
-
-        it('getOrCreate an existing Stream', () => client.getOrCreateStream({
-            name,
         })
-            .then((existingStream) => {
-                assert.equal(existingStream.id, createdStream.id)
-                assert.equal(existingStream.name, createdStream.name)
-            }))
 
-        it('getOrCreate a new Stream', () => {
-            const newName = Date.now()
-                .toString()
-            return client.getOrCreateStream({
+        it('getOrCreate an existing Stream', async () => {
+            const existingStream = await client.getOrCreateStream({
+                name,
+            })
+            assert.equal(existingStream.id, createdStream.id)
+            assert.equal(existingStream.name, createdStream.name)
+        })
+
+        it('getOrCreate a new Stream', async () => {
+            const newName = Date.now().toString()
+            const newStream = await client.getOrCreateStream({
                 name: newName,
             })
-                .then((newStream) => {
-                    assert.notEqual(newStream.id, createdStream.id)
-                })
+
+            assert.notEqual(newStream.id, createdStream.id)
         })
     })
 
@@ -110,48 +110,44 @@ describe('StreamEndpoints', () => {
     })
 
     describe('Stream.update', () => {
-        it('can change stream name', () => {
+        it('can change stream name', async () => {
             createdStream.name = 'New name'
-            return createdStream.update()
+            await createdStream.update()
         })
     })
 
     describe('Stream configuration', () => {
-        it('Stream.detectFields', (done) => {
-            client.connect().then(() => {
-                client.publish(createdStream.id, {
-                    foo: 'bar',
-                    count: 0,
-                }).then(() => {
-                    // Need time to propagate to storage
-                    setTimeout(() => {
-                        createdStream.detectFields().then((stream) => {
-                            assert.deepEqual(
-                                stream.config.fields,
-                                [
-                                    {
-                                        name: 'foo',
-                                        type: 'string',
-                                    },
-                                    {
-                                        name: 'count',
-                                        type: 'number',
-                                    },
-                                ],
-                            )
-                            done()
-                        })
-                        client.disconnect()
-                    }, 10000)
-                }).catch((err) => { throw err })
+        it('Stream.detectFields', async () => {
+            await client.ensureConnected()
+            await client.publish(createdStream.id, {
+                foo: 'bar',
+                count: 0,
             })
+            // Need time to propagate to storage
+            await wait(10000)
+            const stream = await createdStream.detectFields()
+            assert.deepEqual(
+                stream.config.fields,
+                [
+                    {
+                        name: 'foo',
+                        type: 'string',
+                    },
+                    {
+                        name: 'count',
+                        type: 'number',
+                    },
+                ],
+            )
+            await client.ensureDisconnected()
         }, 15000)
     })
 
     describe('Stream permissions', () => {
         it('Stream.getPermissions', async () => {
             const permissions = await createdStream.getPermissions()
-            assert.equal(permissions.length, 6, `Unexpected number of permissions: ${JSON.stringify(permissions)}`) // get, edit, delete, subscribe, publish, share
+            // get, edit, delete, subscribe, publish, share
+            assert.equal(permissions.length, 6, `Unexpected number of permissions: ${JSON.stringify(permissions)}`)
         })
 
         it('Stream.hasPermission', async () => {
@@ -171,6 +167,11 @@ describe('StreamEndpoints', () => {
     })
 
     describe('Stream deletion', () => {
-        it('Stream.delete', () => createdStream.delete())
+        it('Stream.delete', async () => {
+            await createdStream.delete()
+            assert.rejects(async () => {
+                await client.getStream(createdStream.id)
+            })
+        })
     })
 })


### PR DESCRIPTION
Tests are passing against the `CORE-1833` branches in `engine-and-editor` and `broker`.

EDIT: after merging from `master` I'm getting the `_crypto.default.generateKeyPairSync is not a function` error. At commit `4c5fb213a140b96ca03d99d6c0f237ec28284a91` it was working, but there was conflicts.

Anyway, tests should pass in CI after the `engine-and-editor` and `broker` branches are merged.