### PR TITLE
Rename nodejs dist file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack --mode=production --progress",
+    "build": "rm dist/* && NODE_ENV=production webpack --mode=production --progress",
     "prepack": "npm run build",
     "dev": "webpack --progress --colors --watch --mode=development",
     "eslint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git://github.com/streamr-dev/streamr-client.git"
   },
-  "main": "dist/streamr-client.js",
+  "main": "dist/streamr-client.nodejs.js",
   "browser": "dist/streamr-client.web.min.js",
   "directories": {
     "test": "test"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,7 @@ const serverConfig = merge({}, commonConfig, {
     externals: [nodeExternals()],
     output: {
         libraryTarget: 'commonjs2',
-        filename: libraryName + '.js',
+        filename: libraryName + '.nodejs.js',
     },
 })
 


### PR DESCRIPTION
Some users tried to import `dist/streamr-client.min.js` in the browser and got confused.

As a quick fix I propose renaming the nodejs build to `dist/streamr-client.nodejs.js` to clearly indicate the target platform instead of omitting it.