### PR TITLE
Publish benchmark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3887,6 +3887,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -10743,6 +10753,12 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
     },
     "pn": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "benchmark": "^2.1.4",
     "core-js": "^3.6.5",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",

--- a/test/benchmarks/publish.js
+++ b/test/benchmarks/publish.js
@@ -1,6 +1,7 @@
 const { Benchmark } = require('benchmark')
 const { ethers } = require('ethers')
 
+// eslint-disable-next-line import/no-unresolved
 const StreamrClient = require('../../dist/streamr-client')
 const config = require('../integration/config')
 

--- a/test/benchmarks/publish.js
+++ b/test/benchmarks/publish.js
@@ -1,0 +1,72 @@
+const { Benchmark } = require('benchmark')
+const { ethers } = require('ethers')
+
+const StreamrClient = require('../../dist/streamr-client')
+const config = require('../integration/config')
+
+const client1 = new StreamrClient({
+    auth: {
+        privateKey: ethers.Wallet.createRandom().privateKey,
+    },
+    autoConnect: true,
+    ...config.clientOptions
+})
+
+const client2 = new StreamrClient({
+    auth: {
+        apiKey: 'tester1-api-key'
+    },
+    publishWithSignature: 'never',
+    autoConnect: true,
+    ...config.clientOptions
+})
+
+const msg = {
+    msg: 'test'
+}
+
+async function run() {
+    let stream1
+    await client1.getOrCreateStream({
+        name: 'node-example-data',
+    }).then((stream) => {
+        stream1 = stream
+    })
+
+    let stream2
+    await client2.getOrCreateStream({
+        name: 'node-example-data',
+    }).then((stream) => {
+        stream2 = stream
+    })
+
+    const suite = new Benchmark.Suite()
+    suite.add('client publishing with signing', {
+        defer: true,
+        fn(deferred) {
+            stream1.publish(msg).then(() => deferred.resolve())
+        }
+    })
+
+    suite.add('client publishing without signing', {
+        defer: true,
+        fn(deferred) {
+            stream2.publish(msg).then(() => deferred.resolve())
+        }
+    })
+
+    suite.on('cycle', (event) => {
+        console.log(String(event.target))
+    })
+
+    suite.on('complete', async function () {
+        console.log('Fastest is ' + this.filter('fastest').map('name'))
+        console.log('Disconnecting clients')
+        await client1.ensureDisconnected()
+        await client2.ensureDisconnected()
+    })
+
+    suite.run()
+}
+
+run()


### PR DESCRIPTION
Decided to add first benchmark.
How to run `node ./test/benchmarks/publish.js`
Results:
```
client publishing with signing x 608 ops/sec ±2.04% (80 runs sampled)
client publishing without signing x 8,668 ops/sec ±3.79% (68 runs sampled)
```
We can add to CI later, just to get numbers using different `Node.js` versions.