### PR TITLE
Error Handling Cleanup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -130,7 +130,7 @@ module.exports = {
     // testEnvironmentOptions: {},
 
     // Adds a location field to test results
-     testLocationInResults: true,
+    testLocationInResults: true,
 
     // The glob patterns Jest uses to detect test files
     // testMatch: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -92,7 +92,7 @@ module.exports = {
     // reporters: undefined,
 
     // Automatically reset mock state between every test
-    // resetMocks: false,
+    resetMocks: true,
 
     // Reset the module registry before running each individual test
     // resetModules: false,
@@ -101,7 +101,7 @@ module.exports = {
     // resolver: null,
 
     // Automatically restore mock state between every test
-    // restoreMocks: false,
+    restoreMocks: true,
 
     // The root directory that Jest should scan for tests and modules within
     // rootDir: null,
@@ -130,7 +130,7 @@ module.exports = {
     // testEnvironmentOptions: {},
 
     // Adds a location field to test results
-    // testLocationInResults: false,
+     testLocationInResults: true,
 
     // The glob patterns Jest uses to detect test files
     // testMatch: [

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -117,9 +117,9 @@ export default class AbstractSubscription extends Subscription {
     _requestGroupKeyAndQueueMessage(msg, start, end) {
         this.emit('groupKeyMissing', msg.getPublisherId(), start, end)
         const publisherId = msg.getPublisherId().toLowerCase()
-        this.nbGroupKeyRequests[publisherId] = this.nbGroupKeyRequests[publisherId] + 1 || 1
+        this.nbGroupKeyRequests[publisherId] = 1
         clearInterval(this.waitingForGroupKey[publisherId])
-        const timer = setInterval(() => {
+        this.waitingForGroupKey[publisherId] = setInterval(() => {
             if (this.nbGroupKeyRequests[publisherId] < MAX_NB_GROUP_KEY_REQUESTS) {
                 this.nbGroupKeyRequests[publisherId] += 1
                 this.emit('groupKeyMissing', msg.getPublisherId(), start, end)
@@ -128,7 +128,6 @@ export default class AbstractSubscription extends Subscription {
                 this._cancelGroupKeyRequest(publisherId)
             }
         }, this.propagationTimeout)
-        this.waitingForGroupKey[publisherId] = timer
         this._addMsgToQueue(msg)
     }
 

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -117,7 +117,7 @@ export default class AbstractSubscription extends Subscription {
     _requestGroupKeyAndQueueMessage(msg, start, end) {
         this.emit('groupKeyMissing', msg.getPublisherId(), start, end)
         const publisherId = msg.getPublisherId().toLowerCase()
-        this.nbGroupKeyRequests[publisherId] = 1
+        this.nbGroupKeyRequests[publisherId] = 1 // reset retry counter
         clearInterval(this.waitingForGroupKey[publisherId])
         this.waitingForGroupKey[publisherId] = setInterval(() => {
             if (this.nbGroupKeyRequests[publisherId] < MAX_NB_GROUP_KEY_REQUESTS) {

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -1,6 +1,4 @@
-import debugFactory from 'debug'
 import { Errors, Utils } from 'streamr-client-protocol'
-import uniqueId from 'lodash.uniqueid'
 
 import VerificationFailedError from './errors/VerificationFailedError'
 import Subscription from './Subscription'
@@ -10,10 +8,14 @@ const { OrderingUtil } = Utils
 
 const MAX_NB_GROUP_KEY_REQUESTS = 10
 
+function decryptErrorToDisplay(error) {
+    const ciphertext = error.streamMessage.getSerializedContent()
+    return ciphertext.length > 100 ? `${ciphertext.slice(0, 100)}...` : ciphertext
+}
+
 export default class AbstractSubscription extends Subscription {
-    constructor(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout, orderMessages = true, onUnableToDecrypt) {
-        super(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout)
-        this.debug = debugFactory(`StreamrClient::${uniqueId(this.constructor.name)}`)
+    constructor(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout, orderMessages = true, onUnableToDecrypt, debug) {
+        super(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout, debug)
         this.callback = callback
         this.pendingResendRequestIds = {}
         this._lastMessageHandlerPromise = {}

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -1,6 +1,5 @@
 import { Errors, Utils } from 'streamr-client-protocol'
 
-import VerificationFailedError from './errors/VerificationFailedError'
 import Subscription from './Subscription'
 import UnableToDecryptError from './errors/UnableToDecryptError'
 

--- a/src/AbstractSubscription.js
+++ b/src/AbstractSubscription.js
@@ -110,7 +110,8 @@ export default class AbstractSubscription extends Subscription {
     _requestGroupKeyAndQueueMessage(msg, start, end) {
         this.emit('groupKeyMissing', msg.getPublisherId(), start, end)
         const publisherId = msg.getPublisherId().toLowerCase()
-        this.nbGroupKeyRequests[publisherId] = 1
+        this.nbGroupKeyRequests[publisherId] = this.nbGroupKeyRequests[publisherId] + 1 || 1
+        clearInterval(this.waitingForGroupKey[publisherId])
         const timer = setInterval(() => {
             if (this.nbGroupKeyRequests[publisherId] < MAX_NB_GROUP_KEY_REQUESTS) {
                 this.nbGroupKeyRequests[publisherId] += 1
@@ -128,8 +129,7 @@ export default class AbstractSubscription extends Subscription {
         this._cancelGroupKeyRequest(publisherId.toLowerCase())
         const queue = this.encryptedMsgsQueues[publisherId.toLowerCase()]
         while (queue.length > 0) {
-            this._decryptAndHandle(queue[0])
-            queue.shift()
+            this._decryptAndHandle(queue.shift())
         }
     }
 

--- a/src/CombinedSubscription.js
+++ b/src/CombinedSubscription.js
@@ -5,11 +5,11 @@ import AbstractSubscription from './AbstractSubscription'
 
 export default class CombinedSubscription extends Subscription {
     constructor(streamId, streamPartition, callback, options, groupKeys, propagationTimeout, resendTimeout, orderMessages = true,
-        onUnableToDecrypt = AbstractSubscription.defaultUnableToDecrypt) {
+        onUnableToDecrypt = AbstractSubscription.defaultUnableToDecrypt, debug) {
         super(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout)
 
         this.sub = new HistoricalSubscription(streamId, streamPartition, callback, options,
-            groupKeys, this.propagationTimeout, this.resendTimeout, orderMessages, onUnableToDecrypt)
+            groupKeys, this.propagationTimeout, this.resendTimeout, orderMessages, onUnableToDecrypt, debug)
         this.realTimeMsgsQueue = []
         this.sub.on('message received', (msg) => {
             if (msg) {
@@ -19,7 +19,7 @@ export default class CombinedSubscription extends Subscription {
         this.sub.on('initial_resend_done', async () => {
             this._unbindListeners(this.sub)
             const realTime = new RealTimeSubscription(streamId, streamPartition, callback,
-                groupKeys, this.propagationTimeout, this.resendTimeout, orderMessages, onUnableToDecrypt)
+                groupKeys, this.propagationTimeout, this.resendTimeout, orderMessages, onUnableToDecrypt, debug)
             this._bindListeners(realTime)
             if (this.sub.orderingUtil) {
                 realTime.orderingUtil.orderedChains = this.sub.orderingUtil.orderedChains

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -29,11 +29,11 @@ class Connection extends EventEmitter {
 
     async connect() {
         if (this.state === Connection.State.CONNECTING) {
-            return Promise.reject(new Error('Already connecting!'))
+            throw new Error('Already connecting!')
         }
 
         if (this.state === Connection.State.CONNECTED) {
-            return Promise.reject(new Error('Already connected!'))
+            throw new Error('Already connected!')
         }
 
         if (this.state === Connection.State.DISCONNECTING) {
@@ -106,19 +106,19 @@ class Connection extends EventEmitter {
         clearTimeout(this._reconnectTimeout)
     }
 
-    disconnect() {
+    async disconnect() {
         this.clearReconnectTimeout()
 
         if (this.state === Connection.State.DISCONNECTING) {
-            return Promise.reject(new Error('Already disconnecting!'))
+            throw new Error('Already disconnecting!')
         }
 
         if (this.state === Connection.State.DISCONNECTED) {
-            return Promise.reject(new Error('Already disconnected!'))
+            throw new Error('Already disconnected!')
         }
 
         if (this.socket === undefined) {
-            return Promise.reject(new Error('Something is wrong: socket is undefined!'))
+            throw new Error('Something is wrong: socket is undefined!')
         }
 
         if (this.state === Connection.State.CONNECTING) {
@@ -148,7 +148,7 @@ class Connection extends EventEmitter {
                 })
 
                 if (process.browser) {
-                    resolve()
+                    resolve(controlLayerRequest)
                 }
             } catch (err) {
                 this.emit('error', err)

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -28,15 +28,6 @@ class Connection extends EventEmitter {
     }
 
     async connect() {
-        try {
-            await this._connect()
-        } catch (err) {
-            this.emit('error', err)
-            throw err
-        }
-    }
-
-    async _connect() {
         if (this.state === Connection.State.CONNECTING) {
             return Promise.reject(new Error('Already connecting!'))
         }
@@ -55,6 +46,7 @@ class Connection extends EventEmitter {
             this.debug('Trying to open new websocket to %s', this.options.url)
             this.socket = new WebSocket(this.options.url)
         }
+
         this.socket.binaryType = 'arraybuffer'
         this.socket.events = new EventEmitter()
 

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -27,7 +27,16 @@ class Connection extends EventEmitter {
         this.emit(state)
     }
 
-    connect() {
+    async connect() {
+        try {
+            await this._connect()
+        } catch (err) {
+            this.emit('error', err)
+            throw err
+        }
+    }
+
+    async _connect() {
         if (this.state === Connection.State.CONNECTING) {
             return Promise.reject(new Error('Already connecting!'))
         }
@@ -43,14 +52,8 @@ class Connection extends EventEmitter {
         }
 
         if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
-            try {
-                this.debug('Trying to open new websocket to %s', this.options.url)
-                this.socket = new WebSocket(this.options.url)
-            } catch (err) {
-                this.emit('error', err)
-                this.debug(err)
-                return Promise.reject(err)
-            }
+            this.debug('Trying to open new websocket to %s', this.options.url)
+            this.socket = new WebSocket(this.options.url)
         }
         this.socket.binaryType = 'arraybuffer'
         this.socket.events = new EventEmitter()

--- a/src/KeyExchangeUtil.js
+++ b/src/KeyExchangeUtil.js
@@ -1,11 +1,10 @@
-import debugFactory from 'debug'
+import uniqueId from 'lodash.uniqueid'
 
 import EncryptionUtil from './EncryptionUtil'
 import InvalidGroupKeyRequestError from './errors/InvalidGroupKeyRequestError'
 import InvalidGroupKeyResponseError from './errors/InvalidGroupKeyResponseError'
 import InvalidGroupKeyError from './errors/InvalidGroupKeyError'
 
-const debug = debugFactory('KeyExchangeUtil')
 const SUBSCRIBERS_EXPIRATION_TIME = 5 * 60 * 1000 // 5 minutes
 
 export default class KeyExchangeUtil {
@@ -16,6 +15,7 @@ export default class KeyExchangeUtil {
 
     constructor(client) {
         this._client = client
+        this.debug = client.debug.extend(uniqueId('KeyExchangeUtil'))
         this.isSubscriberPromises = {}
     }
 
@@ -86,7 +86,7 @@ export default class KeyExchangeUtil {
         /* eslint-disable no-underscore-dangle */
         this._client._setGroupKeys(parsedContent.streamId, streamMessage.getPublisherId(), decryptedGroupKeys)
         /* eslint-enable no-underscore-dangle */
-        debug('INFO: Updated group key for stream "%s" and publisher "%s"', parsedContent.streamId, streamMessage.getPublisherId())
+        this.debug('INFO: Updated group key for stream "%s" and publisher "%s"', parsedContent.streamId, streamMessage.getPublisherId())
     }
 
     async getSubscribers(streamId) {

--- a/src/MessageCreationUtil.js
+++ b/src/MessageCreationUtil.js
@@ -203,7 +203,7 @@ export default class MessageCreationUtil {
         return streamMessage
     }
 
-    async createErrorMessage({ destinationAddress, streamId, error, requestId }) {
+    async createErrorMessage({ keyExchangeStreamId, streamId, error, requestId }) {
         if (!this._signer) {
             throw new Error('Cannot create unsigned error message. Must authenticate with "privateKey" or "provider"')
         }
@@ -214,7 +214,7 @@ export default class MessageCreationUtil {
             streamId,
             requestId,
         }
-        const [messageId, prevMsgRef] = this.createDefaultMsgIdAndPrevRef(destinationAddress, publisherId)
+        const [messageId, prevMsgRef] = this.createDefaultMsgIdAndPrevRef(keyExchangeStreamId, publisherId)
         const streamMessage = new StreamMessage({
             messageId,
             prevMsgRef,

--- a/src/MessageCreationUtil.js
+++ b/src/MessageCreationUtil.js
@@ -18,10 +18,10 @@ const { StreamMessage, MessageID, MessageRef } = MessageLayer
 const { getKeyExchangeStreamId } = KeyExchangeUtil
 
 export default class MessageCreationUtil {
-    constructor(auth, signer, userInfoPromise, getStreamFunction, keyStorageUtil) {
+    constructor(auth, signer, getUserInfo, getStreamFunction, keyStorageUtil) {
         this.auth = auth
         this._signer = signer
-        this.userInfoPromise = userInfoPromise
+        this.getUserInfo = getUserInfo
         this.getStreamFunction = getStreamFunction
         this.cachedStreams = new Receptacle({
             max: 10000,
@@ -39,7 +39,7 @@ export default class MessageCreationUtil {
     async getUsername() {
         if (!this.usernamePromise) {
             // In the edge case where StreamrClient.auth.apiKey is an anonymous key, userInfo.id is that anonymous key
-            this.usernamePromise = this.userInfoPromise.then((userInfo) => userInfo.username || userInfo.id)
+            this.usernamePromise = this.getUserInfo().then((userInfo) => userInfo.username || userInfo.id)
         }
         return this.usernamePromise
     }

--- a/src/MessageCreationUtil.js
+++ b/src/MessageCreationUtil.js
@@ -214,7 +214,7 @@ export default class MessageCreationUtil {
             streamId,
             requestId,
         }
-        const [messageId, prevMsgRef] = this.createDefaultMsgIdAndPrevRef(destinationAddress.toLowerCase(), publisherId)
+        const [messageId, prevMsgRef] = this.createDefaultMsgIdAndPrevRef(destinationAddress, publisherId)
         const streamMessage = new StreamMessage({
             messageId,
             prevMsgRef,

--- a/src/RealTimeSubscription.js
+++ b/src/RealTimeSubscription.js
@@ -1,16 +1,23 @@
 import debugFactory from 'debug'
+import uniqueId from 'lodash.uniqueid'
 
 import Subscription from './Subscription'
 import AbstractSubscription from './AbstractSubscription'
 import EncryptionUtil from './EncryptionUtil'
 import UnableToDecryptError from './errors/UnableToDecryptError'
 
-const debug = debugFactory('StreamrClient::Subscription')
-
 export default class RealTimeSubscription extends AbstractSubscription {
     constructor(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout, orderMessages = true,
-        onUnableToDecrypt = AbstractSubscription.defaultUnableToDecrypt) {
+        onUnableToDecrypt = AbstractSubscription.defaultUnableToDecrypt, debug) {
         super(streamId, streamPartition, callback, groupKeys, propagationTimeout, resendTimeout, orderMessages, onUnableToDecrypt)
+
+        const id = uniqueId('Subscription')
+        if (debug) {
+            this.debug = debug.extend(id)
+        } else {
+            this.debug = debugFactory(`StreamrClient::${id}`)
+        }
+
         this.alreadyFailedToDecrypt = {}
         this.resending = false
     }
@@ -62,7 +69,7 @@ export default class RealTimeSubscription extends AbstractSubscription {
     }
 
     setResending(resending) {
-        debug(`Subscription: Stream ${this.streamId} resending: ${resending}`)
+        this.debug(`Subscription: Stream ${this.streamId} resending: ${resending}`)
         this.resending = resending
     }
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -58,7 +58,7 @@ export default class Session extends EventEmitter {
                     this.options.sessionToken = tokenObj.token
                     this.updateState(Session.State.LOGGED_IN)
                     return tokenObj.token
-                }).catch((err) => {
+                }, (err) => {
                     this.updateState(Session.State.LOGGED_OUT)
                     throw err
                 })

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -240,12 +240,12 @@ export default class StreamrClient extends EventEmitter {
 
         // On connect/reconnect, send pending subscription requests
         this.connection.on('connected', async () => {
-            await new Promise((resolve) => setTimeout(resolve, 0)) // wait a tick
+            await new Promise((resolve) => setTimeout(resolve, 0)) // wait a tick to let event handlers finish
             if (!this.isConnected()) { return }
             this.debug('Connected!')
             this.emit('connected')
             try {
-                await this._subscribeToInboxStream()
+                await this._subscribeToKeyExchangeStream()
                 if (!this.isConnected()) { return }
                 // Check pending subscriptions
                 Object.keys(this.subscribedStreamPartitions).forEach((key) => {
@@ -311,12 +311,12 @@ export default class StreamrClient extends EventEmitter {
         console.error(error)
     }
 
-    async _subscribeToInboxStream() {
+    async _subscribeToKeyExchangeStream() {
         if (!this.options.auth.privateKey && !this.options.auth.provider) {
             return
         }
         await this.session.getSessionToken() // trigger auth errors if any
-        // subscribing to own inbox stream
+        // subscribing to own keyexchange stream
         const publisherId = await this.getPublisherId()
         const streamId = KeyExchangeUtil.getKeyExchangeStreamId(publisherId)
         this.subscribe(streamId, async (parsedContent, streamMessage) => {

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -4,17 +4,7 @@ import qs from 'qs'
 import once from 'once'
 import { Wallet } from 'ethers'
 import { ControlLayer, MessageLayer, Errors } from 'streamr-client-protocol'
-
-const {
-    SubscribeRequest,
-    UnsubscribeRequest,
-    ResendLastRequest,
-    ResendFromRequest,
-    ResendRangeRequest,
-    ControlMessage,
-} = ControlLayer
-const { StreamMessage, MessageRef } = MessageLayer
-const debug = debugFactory('StreamrClient')
+import uniqueId from 'lodash.uniqueid'
 
 import HistoricalSubscription from './HistoricalSubscription'
 import Connection from './Connection'
@@ -24,7 +14,7 @@ import SubscribedStreamPartition from './SubscribedStreamPartition'
 import Stream from './rest/domain/Stream'
 import FailedToPublishError from './errors/FailedToPublishError'
 import MessageCreationUtil from './MessageCreationUtil'
-import { waitFor, getVersionString } from './utils'
+import { waitFor, getVersionString, uuid } from './utils'
 import RealTimeSubscription from './RealTimeSubscription'
 import CombinedSubscription from './CombinedSubscription'
 import Subscription from './Subscription'
@@ -34,12 +24,25 @@ import KeyStorageUtil from './KeyStorageUtil'
 import ResendUtil from './ResendUtil'
 import InvalidContentTypeError from './errors/InvalidContentTypeError'
 
+const {
+    SubscribeRequest,
+    UnsubscribeRequest,
+    ResendLastRequest,
+    ResendFromRequest,
+    ResendRangeRequest,
+    ControlMessage,
+} = ControlLayer
+
+const { StreamMessage, MessageRef } = MessageLayer
+
 export default class StreamrClient extends EventEmitter {
     constructor(options, connection) {
         super()
-
+        this.id = uniqueId('StreamrClient')
+        this.debug = debugFactory(this.id)
         // Default options
         this.options = {
+            debug: this.debug,
             // The server to connect to
             url: 'wss://streamr.network/api/v1/ws',
             restUrl: 'https://streamr.network/api/v1',
@@ -117,7 +120,10 @@ export default class StreamrClient extends EventEmitter {
 
         this.publishQueue = []
         this.session = new Session(this, this.options.auth)
-        this.signer = Signer.createSigner(this.options.auth, this.options.publishWithSignature)
+        this.signer = Signer.createSigner({
+            ...this.options.auth,
+            debug: this.debug,
+        }, this.options.publishWithSignature)
         // Event handling on connection object
         this.connection = connection || new Connection(this.options)
 
@@ -148,7 +154,7 @@ export default class StreamrClient extends EventEmitter {
                 // sub.handleBroadcastMessage never rejects: on any error it emits an 'error' event on the Subscription
                 stream.getSubscriptions().forEach((sub) => sub.handleBroadcastMessage(msg.streamMessage, verifyFn))
             } else {
-                debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
+                this.debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
             }
         })
 
@@ -165,10 +171,10 @@ export default class StreamrClient extends EventEmitter {
                         once(() => stream.verifyStreamMessage(msg.streamMessage)), // ensure verification occurs only once
                     )
                 } else {
-                    debug('WARN: request id not found for stream: %s, sub: %s', msg.streamMessage.getStreamId(), msg.requestId)
+                    this.debug('WARN: request id not found for stream: %s, sub: %s', msg.streamMessage.getStreamId(), msg.requestId)
                 }
             } else {
-                debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
+                this.debug('WARN: message received for stream with no subscriptions: %s', msg.streamMessage.getStreamId())
             }
         })
 
@@ -179,11 +185,11 @@ export default class StreamrClient extends EventEmitter {
                 stream.getSubscriptions().filter((sub) => !sub.resending)
                     .forEach((sub) => sub.setState(Subscription.State.subscribed))
             }
-            debug('Client subscribed: streamId: %s, streamPartition: %s', response.streamId, response.streamPartition)
+            this.debug('Client subscribed: streamId: %s, streamPartition: %s', response.streamId, response.streamPartition)
         })
 
         this.connection.on(ControlMessage.TYPES.UnsubscribeResponse, (response) => {
-            debug('Client unsubscribed: streamId: %s, streamPartition: %s', response.streamId, response.streamPartition)
+            this.debug('Client unsubscribed: streamId: %s, streamPartition: %s', response.streamId, response.streamPartition)
             const stream = this._getSubscribedStreamPartition(response.streamId, response.streamPartition)
             if (stream) {
                 stream.getSubscriptions().forEach((sub) => {
@@ -203,7 +209,7 @@ export default class StreamrClient extends EventEmitter {
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleResending(response)
             } else {
-                debug('resent: Subscription %s is gone already', response.requestId)
+                this.debug('resent: Subscription %s is gone already', response.requestId)
             }
         })
 
@@ -215,7 +221,7 @@ export default class StreamrClient extends EventEmitter {
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleNoResend(response)
             } else {
-                debug('resent: Subscription %s is gone already', response.requestId)
+                this.debug('resent: Subscription %s is gone already', response.requestId)
             }
         })
 
@@ -227,13 +233,13 @@ export default class StreamrClient extends EventEmitter {
             if (stream && sub && stream.getSubscription(sub.id)) {
                 stream.getSubscription(sub.id).handleResent(response)
             } else {
-                debug('resent: Subscription %s is gone already', response.requestId)
+                this.debug('resent: Subscription %s is gone already', response.requestId)
             }
         })
 
         // On connect/reconnect, send pending subscription requests
         this.connection.on('connected', async () => {
-            debug('Connected!')
+            this.debug('Connected!')
             this.emit('connected')
 
             await this._subscribeToInboxStream()
@@ -255,7 +261,7 @@ export default class StreamrClient extends EventEmitter {
         })
 
         this.connection.on('disconnected', () => {
-            debug('Disconnected.')
+            this.debug('Disconnected.')
             this.emit('disconnected')
 
             Object.keys(this.subscribedStreamPartitions)
@@ -280,7 +286,7 @@ export default class StreamrClient extends EventEmitter {
                 if (stream) {
                     stream.getSubscriptions().forEach((sub) => sub.handleError(err))
                 } else {
-                    debug('WARN: InvalidJsonError received for stream with no subscriptions: %s', err.streamId)
+                    this.debug('WARN: InvalidJsonError received for stream with no subscriptions: %s', err.streamId)
                 }
             } else {
                 // if it looks like an error emit as-is, otherwise wrap in new Error
@@ -301,7 +307,7 @@ export default class StreamrClient extends EventEmitter {
                         try {
                             await this.keyExchangeUtil.handleGroupKeyRequest(streamMessage)
                         } catch (error) {
-                            debug('WARN: %s', error.message)
+                            this.debug('WARN: %s', error.message)
                             const msg = streamMessage.getParsedContent()
                             const errorMessage = await this.msgCreationUtil.createErrorMessage({
                                 destinationAddress: streamId,
@@ -317,7 +323,7 @@ export default class StreamrClient extends EventEmitter {
                         this.keyExchangeUtil.handleGroupKeyResponse(streamMessage)
                     }
                 } else if (streamMessage.contentType === StreamMessage.CONTENT_TYPES.GROUP_KEY_ERROR_RESPONSE) {
-                    debug('WARN: Received error of type %s from %s: %s',
+                    this.debug('WARN: Received error of type %s from %s: %s',
                         streamMessage.getParsedContent().code, streamMessage.getPublisherId(), streamMessage.getParsedContent().message)
                 } else {
                     throw new InvalidContentTypeError(`Cannot handle message with content type: ${streamMessage.contentType}`)
@@ -422,7 +428,7 @@ export default class StreamrClient extends EventEmitter {
                     try {
                         publishRequest = await this._requestPublish(streamMessage, sessionToken)
                     } catch (err) {
-                        debug(`Error: ${err}`)
+                        this.debug(`Error: ${err}`)
                         this.emit('error', err)
                         reject(err)
                         return
@@ -457,7 +463,7 @@ export default class StreamrClient extends EventEmitter {
 
         const sub = new HistoricalSubscription(options.stream, options.partition || 0, callback, options.resend,
             this.options.subscriberGroupKeys[options.stream], this.options.gapFillTimeout, this.options.retryResendAfter,
-            this.options.orderMessages, options.onUnableToDecrypt)
+            this.options.orderMessages, options.onUnableToDecrypt, this.debug)
 
         // TODO remove _addSubscription after uncoupling Subscription and Resend
         sub.setState(Subscription.State.subscribed)
@@ -527,12 +533,12 @@ export default class StreamrClient extends EventEmitter {
             sub = new CombinedSubscription(
                 options.stream, options.partition || 0, callback, options.resend,
                 groupKeys, this.options.gapFillTimeout, this.options.retryResendAfter,
-                this.options.orderMessages, options.onUnableToDecrypt,
+                this.options.orderMessages, options.onUnableToDecrypt, this.debug,
             )
         } else {
             sub = new RealTimeSubscription(options.stream, options.partition || 0, callback,
                 groupKeys, this.options.gapFillTimeout, this.options.retryResendAfter,
-                this.options.orderMessages, options.onUnableToDecrypt)
+                this.options.orderMessages, options.onUnableToDecrypt, this.debug)
         }
         sub.on('gap', (from, to, publisherId, msgChainId) => {
             if (!sub.resending) {
@@ -542,7 +548,7 @@ export default class StreamrClient extends EventEmitter {
             }
         })
         sub.on('done', () => {
-            debug('done event for sub %d', sub.id)
+            this.debug('done event for sub %d', sub.id)
             this.unsubscribe(sub)
         })
         sub.on('groupKeyMissing', async (messagePublisherAddress, start, end) => {
@@ -648,7 +654,7 @@ export default class StreamrClient extends EventEmitter {
             return Promise.reject(new Error('Already connecting!'))
         }
 
-        debug('Connecting to %s', this.options.url)
+        this.debug('Connecting to %s', this.options.url)
         return this.connection.connect()
     }
 
@@ -714,7 +720,7 @@ export default class StreamrClient extends EventEmitter {
     _checkAutoDisconnect() {
         // Disconnect if no longer subscribed to any streams
         if (this.options.autoDisconnect && Object.keys(this.subscribedStreamPartitions).length === 0) {
-            debug('Disconnecting due to no longer being subscribed to any streams')
+            this.debug('Disconnecting due to no longer being subscribed to any streams')
             this.disconnect()
         }
     }
@@ -768,7 +774,7 @@ export default class StreamrClient extends EventEmitter {
                 sessionToken,
                 requestId: this.resendUtil.generateRequestId(),
             })
-            debug('_requestSubscribe: subscribing client: %o', request)
+            this.debug('_requestSubscribe: subscribing client: %o', request)
             sp.setSubscribing(true)
             await this.connection.send(request).catch((err) => {
                 sub.setState(Subscription.State.unsubscribed)
@@ -776,7 +782,7 @@ export default class StreamrClient extends EventEmitter {
             })
         } else if (subscribedSubs.length > 0) {
             // If there already is a subscribed subscription for this stream, this new one will just join it immediately
-            debug('_requestSubscribe: another subscription for same stream: %s, insta-subscribing', sub.streamId)
+            this.debug('_requestSubscribe: another subscription for same stream: %s, insta-subscribing', sub.streamId)
 
             setTimeout(() => {
                 sub.setState(Subscription.State.subscribed)
@@ -785,7 +791,7 @@ export default class StreamrClient extends EventEmitter {
     }
 
     async _requestUnsubscribe(sub) {
-        debug('Client unsubscribing stream %o partition %o', sub.streamId, sub.streamPartition)
+        this.debug('Client unsubscribing stream %o partition %o', sub.streamId, sub.streamPartition)
         const unsubscribeRequest = new UnsubscribeRequest({
             streamId: sub.streamId,
             streamPartition: sub.streamPartition,
@@ -837,7 +843,7 @@ export default class StreamrClient extends EventEmitter {
         }
 
         if (request) {
-            debug('_requestResend: %o', request)
+            this.debug('_requestResend: %o', request)
             await this.connection.send(request).catch((err) => {
                 this.handleError(`Failed to send resend request: ${err}`)
             })
@@ -858,7 +864,7 @@ export default class StreamrClient extends EventEmitter {
             requestId,
             sessionToken,
         })
-        debug('_requestPublish: %o', request)
+        this.debug('_requestPublish: %o', request)
         return this.connection.send(request)
     }
 
@@ -877,7 +883,7 @@ export default class StreamrClient extends EventEmitter {
     }
 
     handleError(msg) {
-        debug(msg)
+        this.debug(msg)
         this.emit('error', msg)
     }
 

--- a/src/StreamrClient.js
+++ b/src/StreamrClient.js
@@ -328,7 +328,7 @@ export default class StreamrClient extends EventEmitter {
                         this.debug('WARN: %s', error.message)
                         const msg = streamMessage.getParsedContent()
                         const errorMessage = await this.msgCreationUtil.createErrorMessage({
-                            destinationAddress: streamId,
+                            keyExchangeStreamId: streamId,
                             requestId: msg.requestId,
                             streamId: msg.streamId,
                             error,

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -22,9 +22,9 @@ export default class Subscription extends EventEmitter {
         const id = uniqueId('sub')
         this.id = id
         if (debug) {
-            this.debug = debug.extend(id)
+            this.debug = debug.extend(this.constructor.name).extend(id)
         } else {
-            this.debug = debugFactory(`StreamrClient::${id}`)
+            this.debug = debugFactory(`StreamrClient::${this.constructor.name}`).extend(id)
         }
 
         if (!streamId) {

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -2,20 +2,16 @@ import EventEmitter from 'eventemitter3'
 import debugFactory from 'debug'
 import uniqueId from 'lodash.uniqueid'
 
-const debug = debugFactory('StreamrClient::Subscription')
-
 const DEFAULT_PROPAGATION_TIMEOUT = 5000
 const DEFAULT_RESEND_TIMEOUT = 5000
+
 /*
 'interface' containing the default parameters and functionalities common to every subscription (Combined, RealTime and Historical)
  */
 export default class Subscription extends EventEmitter {
     constructor(streamId, streamPartition, callback, groupKeys,
-        propagationTimeout = DEFAULT_PROPAGATION_TIMEOUT, resendTimeout = DEFAULT_RESEND_TIMEOUT) {
+        propagationTimeout = DEFAULT_PROPAGATION_TIMEOUT, resendTimeout = DEFAULT_RESEND_TIMEOUT, debug) {
         super()
-        if (!streamId) {
-            throw new Error('No stream id given!')
-        }
 
         if (!callback) {
             throw new Error('No callback given!')
@@ -23,7 +19,17 @@ export default class Subscription extends EventEmitter {
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.callback = callback
-        this.id = uniqueId('sub')
+        const id = uniqueId('sub')
+        this.id = id
+        if (debug) {
+            this.debug = debug.extend(id)
+        } else {
+            this.debug = debugFactory(`StreamrClient::${id}`)
+        }
+
+        if (!streamId) {
+            throw new Error('No stream id given!')
+        }
         this.groupKeys = {}
         if (groupKeys) {
             Object.keys(groupKeys).forEach((publisherId) => {
@@ -40,7 +46,7 @@ export default class Subscription extends EventEmitter {
     }
 
     setState(state) {
-        debug(`Subscription: Stream ${this.streamId} state changed ${this.state} => ${state}`)
+        this.debug(`Subscription: Stream ${this.streamId} state changed ${this.state} => ${state}`)
         this.state = state
         this.emit(state)
     }

--- a/src/rest/LoginEndpoints.js
+++ b/src/rest/LoginEndpoints.js
@@ -15,6 +15,9 @@ async function getSessionToken(url, props) {
 }
 
 export async function getChallenge(address) {
+    this.debug('getChallenge', {
+        address,
+    })
     const url = `${this.options.restUrl}/login/challenge/${address}`
     return authFetch(
         url,
@@ -26,6 +29,11 @@ export async function getChallenge(address) {
 }
 
 export async function sendChallengeResponse(challenge, signature, address) {
+    this.debug('sendChallengeResponse', {
+        challenge,
+        signature,
+        address,
+    })
     const url = `${this.options.restUrl}/login/response`
     const props = {
         challenge,
@@ -36,12 +44,18 @@ export async function sendChallengeResponse(challenge, signature, address) {
 }
 
 export async function loginWithChallengeResponse(signingFunction, address) {
+    this.debug('loginWithChallengeResponse', {
+        address,
+    })
     const challenge = await this.getChallenge(address)
     const signature = await signingFunction(challenge.challenge)
     return this.sendChallengeResponse(challenge, signature, address)
 }
 
 export async function loginWithApiKey(apiKey) {
+    this.debug('loginWithApiKey', {
+        apiKey,
+    })
     const url = `${this.options.restUrl}/login/apikey`
     const props = {
         apiKey,
@@ -50,6 +64,9 @@ export async function loginWithApiKey(apiKey) {
 }
 
 export async function loginWithUsernamePassword(username, password) {
+    this.debug('loginWithUsernamePassword', {
+        username,
+    })
     const url = `${this.options.restUrl}/login/password`
     const props = {
         username,
@@ -59,10 +76,12 @@ export async function loginWithUsernamePassword(username, password) {
 }
 
 export async function getUserInfo() {
+    this.debug('getUserInfo')
     return authFetch(`${this.options.restUrl}/users/me`, this.session)
 }
 
 export async function logoutEndpoint() {
+    this.debug('logoutEndpoint')
     return authFetch(`${this.options.restUrl}/logout`, this.session, {
         method: 'POST',
     })

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -34,18 +34,27 @@ function getKeepAliveAgentForUrl(url) {
 // These function are mixed in to StreamrClient.prototype.
 // In the below functions, 'this' is intended to be the StreamrClient
 export async function getStream(streamId) {
+    this.debug('getStream', {
+        streamId,
+    })
     const url = `${this.options.restUrl}/streams/${streamId}`
     const json = await authFetch(url, this.session)
     return json ? new Stream(this, json) : undefined
 }
 
 export async function listStreams(query = {}) {
+    this.debug('listStreams', {
+        query,
+    })
     const url = `${this.options.restUrl}/streams?${qs.stringify(query)}`
     const json = await authFetch(url, this.session)
     return json ? json.map((stream) => new Stream(this, stream)) : []
 }
 
 export async function getStreamByName(name) {
+    this.debug('getStreamByName', {
+        name,
+    })
     const json = await this.listStreams({
         name,
         public: false,
@@ -54,6 +63,9 @@ export async function getStreamByName(name) {
 }
 
 export async function createStream(props) {
+    this.debug('getStreamByName', {
+        props,
+    })
     if (!props || !props.name) {
         throw new Error('Stream properties must contain a "name" field!')
     }
@@ -70,6 +82,9 @@ export async function createStream(props) {
 }
 
 export async function getOrCreateStream(props) {
+    this.debug('getOrCreateStream', {
+        props,
+    })
     let json
 
     // Try looking up the stream by id or name, whichever is defined
@@ -94,12 +109,19 @@ export async function getOrCreateStream(props) {
 }
 
 export async function getStreamPublishers(streamId) {
+    this.debug('getStreamPublishers', {
+        streamId,
+    })
     const url = `${this.options.restUrl}/streams/${streamId}/publishers`
     const json = await authFetch(url, this.session)
     return json.addresses.map((a) => a.toLowerCase())
 }
 
 export async function isStreamPublisher(streamId, ethAddress) {
+    this.debug('isStreamPublisher', {
+        streamId,
+        ethAddress,
+    })
     const url = `${this.options.restUrl}/streams/${streamId}/publisher/${ethAddress}`
     try {
         await authFetch(url, this.session)
@@ -113,12 +135,19 @@ export async function isStreamPublisher(streamId, ethAddress) {
 }
 
 export async function getStreamSubscribers(streamId) {
+    this.debug('getStreamSubscribers', {
+        streamId,
+    })
     const url = `${this.options.restUrl}/streams/${streamId}/subscribers`
     const json = await authFetch(url, this.session)
     return json.addresses.map((a) => a.toLowerCase())
 }
 
 export async function isStreamSubscriber(streamId, ethAddress) {
+    this.debug('isStreamSubscriber', {
+        streamId,
+        ethAddress,
+    })
     const url = `${this.options.restUrl}/streams/${streamId}/subscriber/${ethAddress}`
     try {
         await authFetch(url, this.session)
@@ -132,6 +161,9 @@ export async function isStreamSubscriber(streamId, ethAddress) {
 }
 
 export async function getStreamValidationInfo(streamId) {
+    this.debug('getStreamValidationInfo', {
+        streamId,
+    })
     const url = `${this.options.restUrl}/streams/${streamId}/validation`
     const json = await authFetch(url, this.session)
     return json
@@ -144,6 +176,9 @@ export function publishHttp(streamObjectOrId, data, requestOptions = {}, keepAli
     } else {
         streamId = streamObjectOrId
     }
+    this.debug('publishHttp', {
+        streamId, data,
+    })
 
     // Send data to the stream
     return authFetch(

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -169,7 +169,7 @@ export async function getStreamValidationInfo(streamId) {
     return json
 }
 
-export function publishHttp(streamObjectOrId, data, requestOptions = {}, keepAlive = true) {
+export async function publishHttp(streamObjectOrId, data, requestOptions = {}, keepAlive = true) {
     let streamId
     if (streamObjectOrId instanceof Stream) {
         streamId = streamObjectOrId.id

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -28,7 +28,7 @@ export default class Stream {
         return result
     }
 
-    delete() {
+    async delete() {
         return authFetch(
             `${this._client.options.restUrl}/streams/${this.id}`,
             this._client.session,
@@ -38,14 +38,14 @@ export default class Stream {
         )
     }
 
-    getPermissions() {
+    async getPermissions() {
         return authFetch(
             `${this._client.options.restUrl}/streams/${this.id}/permissions`,
             this._client.session,
         )
     }
 
-    getMyPermissions() {
+    async getMyPermissions() {
         return authFetch(
             `${this._client.options.restUrl}/streams/${this.id}/permissions/me`,
             this._client.session,
@@ -68,7 +68,7 @@ export default class Stream {
         })
     }
 
-    grantPermission(operation, userId) {
+    async grantPermission(operation, userId) {
         const permissionObject = {
             operation,
         }
@@ -91,7 +91,7 @@ export default class Stream {
         )
     }
 
-    revokePermission(permissionId) {
+    async revokePermission(permissionId) {
         return authFetch(
             `${this._client.options.restUrl}/streams/${this.id}/permissions/${permissionId}`,
             this._client.session,
@@ -101,14 +101,14 @@ export default class Stream {
         )
     }
 
-    detectFields() {
+    async detectFields() {
         return authFetch(
             `${this._client.options.restUrl}/streams/${this.id}/detectFields`,
             this._client.session,
         )
     }
 
-    publish(...theArgs) {
+    async publish(...theArgs) {
         return this._client.publish(this.id, ...theArgs)
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ import pkg from '../package.json'
 const UUID = uuidv4()
 
 export function uuid(label = '') {
-    return uniqueId(`p${UUID}${label ? `.${label}` : ''}`) // incrementing + human readable uuid
+    return uniqueId(`${UUID}${label ? `.${label}` : ''}`) // incrementing + human readable uuid
 }
 
 export function getVersionString() {

--- a/test/integration/MultipleClients.test.js
+++ b/test/integration/MultipleClients.test.js
@@ -1,0 +1,77 @@
+import { ethers } from 'ethers'
+import { wait, waitForCondition } from 'streamr-test-utils'
+
+import StreamrClient from '../../src'
+import { uid } from '../utils'
+
+import config from './config'
+
+describe('multiple users', () => {
+    let client1
+    let client2
+    let errors = []
+    function onError(error) {
+        errors.push(error)
+    }
+    beforeEach(async () => {
+        errors = []
+    })
+
+    afterEach(async () => {
+        if (client1) {
+            client1.removeListener('error', onError)
+            await client1.ensureDisconnected()
+        }
+
+        if (client2) {
+            client2.removeListener('error', onError)
+            await client2.ensureDisconnected()
+        }
+
+        expect(errors[0]).toBeFalsy()
+        expect(errors).toHaveLength(0)
+    })
+
+    it('works with multiple identities', async () => {
+        const wallet1 = ethers.Wallet.createRandom()
+        const wallet2 = ethers.Wallet.createRandom()
+        client1 = new StreamrClient({
+            auth: {
+                privateKey: wallet1.privateKey,
+            },
+            autoConnect: false,
+            autoDisconnect: false,
+            ...config.clientOptions,
+        })
+        await client1.ensureConnected()
+        const stream = await client1.createStream({
+            name: uid('stream')
+        })
+        await stream.grantPermission('stream_get', wallet2.address)
+        await stream.grantPermission('stream_subscribe', wallet2.address)
+        // NOTE: currently have to connect second client after permissions granted or backend errors
+        client2 = new StreamrClient({
+            auth: {
+                privateKey: wallet1.privateKey,
+            },
+            autoConnect: false,
+            autoDisconnect: false,
+            ...config.clientOptions,
+        })
+
+        await client2.ensureConnected()
+
+        const receivedMessages = []
+        const sub = client2.subscribe(stream.id, (msg) => {
+            receivedMessages.push(msg)
+        })
+        await new Promise((resolve) => sub.once('subscribed', resolve))
+
+        const msg = {
+            msg: uid('msg'),
+        }
+        await client1.publish(stream.id, msg)
+        await waitForCondition(() => receivedMessages.length === 1, 10000)
+        expect(receivedMessages).toEqual([msg])
+    })
+})

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -206,8 +206,7 @@ describe('StreamrClient Connection', () => {
                 ])
                 done()
             })
-
-            await waitForCondition(() => messages.length === 2)
+            await waitForCondition(() => messages.length >= 2)
         }, 10000)
 
         it('resend range', async (done) => {
@@ -245,7 +244,7 @@ describe('StreamrClient Connection', () => {
                 done()
             })
 
-            await waitForCondition(() => messages.length === 3)
+            await waitForCondition(() => messages.length >= 3)
         }, 10000)
     })
 

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -154,6 +154,8 @@ describe('StreamrClient Connection', () => {
                 // eslint-disable-next-line no-await-in-loop
                 const rawMessage = await client.publish(stream.id, message)
                 timestamps.push(rawMessage.streamMessage.getTimestamp())
+                // eslint-disable-next-line no-await-in-loop
+                await wait(100) // ensure timestamp increments for reliable resend response in test.
             }
 
             await wait(5000) // wait for messages to (probably) land in storage

--- a/test/integration/authFetch.test.js
+++ b/test/integration/authFetch.test.js
@@ -14,6 +14,10 @@ describe('authFetch', () => {
         await client.ensureDisconnected()
     })
 
+    afterAll(() => {
+        jest.restoreAllMocks()
+    })
+
     it('sends Streamr-Client header', async () => {
         client = new StreamrClient({
             auth: {
@@ -24,6 +28,8 @@ describe('authFetch', () => {
             ...config.clientOptions,
         })
         await client.connect()
+        expect(fetch).not.toHaveBeenCalled() // will get called in background though (questionable behaviour)
+        await client.session.getSessionToken() // this ensures authentication completed
         expect(fetch).toHaveBeenCalled()
         fetch.mock.calls.forEach(([url, opts]) => {
             expect(typeof url).toEqual('string')

--- a/test/integration/authFetch.test.js
+++ b/test/integration/authFetch.test.js
@@ -1,7 +1,7 @@
-jest.mock('node-fetch', () => jest.fn(jest.requireActual('node-fetch')))
+jest.mock('node-fetch')
 
-import fetch from 'node-fetch'
 import { ethers } from 'ethers'
+import fetch from 'node-fetch'
 
 import StreamrClient from '../../src'
 
@@ -19,6 +19,12 @@ describe('authFetch', () => {
     })
 
     it('sends Streamr-Client header', async () => {
+        const realFetch = jest.requireActual('node-fetch')
+        fetch.Response = realFetch.Response
+        fetch.Promise = realFetch.Promise
+        fetch.Request = realFetch.Request
+        fetch.Headers = realFetch.Headers
+        fetch.mockImplementation(realFetch)
         client = new StreamrClient({
             auth: {
                 privateKey: ethers.Wallet.createRandom().privateKey,

--- a/test/unit/Connection.test.js
+++ b/test/unit/Connection.test.js
@@ -1,4 +1,5 @@
 import { ControlLayer, MessageLayer } from 'streamr-client-protocol'
+import { wait } from 'streamr-test-utils'
 
 import Connection from '../../src/Connection'
 
@@ -221,18 +222,10 @@ describe('Connection', () => {
         })
 
         describe('close', () => {
-            beforeAll(() => {
-                jest.useFakeTimers()
-            })
-
-            afterAll(() => {
-                jest.useRealTimers()
-            })
-
-            it('tries to reconnect after 2 seconds', () => {
+            it('tries to reconnect after 2 seconds', async () => {
                 conn.connect = jest.fn(async () => {})
                 conn.socket.events.emit('close')
-                jest.advanceTimersByTime(2100)
+                await wait(2100)
                 expect(conn.connect).toHaveBeenCalledTimes(1)
             })
         })

--- a/test/unit/KeyExchangeUtil.test.js
+++ b/test/unit/KeyExchangeUtil.test.js
@@ -2,13 +2,13 @@ import crypto from 'crypto'
 
 import sinon from 'sinon'
 import { MessageLayer } from 'streamr-client-protocol'
+import debugFactory from 'debug'
 
 import KeyExchangeUtil from '../../src/KeyExchangeUtil'
 import EncryptionUtil from '../../src/EncryptionUtil'
 import KeyStorageUtil from '../../src/KeyStorageUtil'
 import InvalidGroupKeyResponseError from '../../src/errors/InvalidGroupKeyResponseError'
 import InvalidGroupKeyRequestError from '../../src/errors/InvalidGroupKeyRequestError'
-import debugFactory from 'debug'
 import { uid } from '../utils'
 
 const { StreamMessage, MessageIDStrict } = MessageLayer

--- a/test/unit/KeyExchangeUtil.test.js
+++ b/test/unit/KeyExchangeUtil.test.js
@@ -8,6 +8,7 @@ import EncryptionUtil from '../../src/EncryptionUtil'
 import KeyStorageUtil from '../../src/KeyStorageUtil'
 import InvalidGroupKeyResponseError from '../../src/errors/InvalidGroupKeyResponseError'
 import InvalidGroupKeyRequestError from '../../src/errors/InvalidGroupKeyRequestError'
+import debugFactory from 'debug'
 import { uid } from '../utils'
 
 const { StreamMessage, MessageIDStrict } = MessageLayer
@@ -19,6 +20,7 @@ subscribers.forEach((p) => {
 
 async function setupClient() {
     const client = {}
+    client.debug = debugFactory('StreamrClient::test')
     client.getStreamSubscribers = sinon.stub()
     client.getStreamSubscribers.withArgs('streamId').resolves(subscribers)
     client.isStreamSubscriber = sinon.stub()

--- a/test/unit/KeyExchangeUtil.test.js
+++ b/test/unit/KeyExchangeUtil.test.js
@@ -89,7 +89,7 @@ describe('KeyExchangeUtil', () => {
         it('should reject request for a stream for which the client does not have a group key', async (done) => {
             const requestId = uid('requestId')
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'subscriber2', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'subscriber2', ''),
                 prevMsgRef: null,
                 content: {
                     streamId: 'wrong-streamId',
@@ -114,7 +114,7 @@ describe('KeyExchangeUtil', () => {
             const subscriberKeyPair = new EncryptionUtil()
             await subscriberKeyPair.onReady()
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'subscriber2', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'subscriber2', ''),
                 prevMsgRef: null,
                 content: {
                     streamId: 'streamId',
@@ -152,7 +152,7 @@ describe('KeyExchangeUtil', () => {
             const subscriberKeyPair = new EncryptionUtil()
             await subscriberKeyPair.onReady()
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'subscriber2', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'subscriber2', ''),
                 prevMsgRef: null,
                 content: {
                     streamId: 'streamId',
@@ -199,7 +199,7 @@ describe('KeyExchangeUtil', () => {
             const subscriberKeyPair = new EncryptionUtil()
             await subscriberKeyPair.onReady()
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'subscriber2', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'subscriber2', ''),
                 prevMsgRef: null,
                 content: {
                     requestId,
@@ -235,7 +235,7 @@ describe('KeyExchangeUtil', () => {
         it('should reject response for a stream to which the client is not subscribed', async (done) => {
             const requestId = uid('requestId')
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'publisherId', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'publisherId', ''),
                 prevMsgRef: null,
                 content: {
                     streamId: 'wrong-streamId',
@@ -264,7 +264,7 @@ describe('KeyExchangeUtil', () => {
             const requestId = uid('requestId')
             const encryptedGroupKey = EncryptionUtil.encryptWithPublicKey(crypto.randomBytes(16), client.encryptionUtil.getPublicKey(), true)
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'publisherId', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'publisherId', ''),
                 prevMsgRef: null,
                 content: {
                     streamId: 'streamId',
@@ -293,7 +293,7 @@ describe('KeyExchangeUtil', () => {
             const groupKey = crypto.randomBytes(32)
             const encryptedGroupKey = EncryptionUtil.encryptWithPublicKey(groupKey, client.encryptionUtil.getPublicKey(), true)
             const streamMessage = new StreamMessage({
-                messageId: new MessageIDStrict('clientInboxAddress', 0, Date.now(), 0, 'publisherId', ''),
+                messageId: new MessageIDStrict('clientKeyExchangeAddress', 0, Date.now(), 0, 'publisherId', ''),
                 prevMsgRef: null,
                 content: {
                     streamId: 'streamId',

--- a/test/unit/MessageCreationUtil.test.js
+++ b/test/unit/MessageCreationUtil.test.js
@@ -506,7 +506,7 @@ describe('MessageCreationUtil', () => {
                 requestId,
             })
 
-            expect(streamMessage.getStreamId()).toBe('destinationAddress'.toLowerCase()) // sending to subscriber's inbox stream
+            expect(streamMessage.getStreamId()).toBe('destinationAddress') // sending to subscriber's inbox stream
 
             const content = streamMessage.getParsedContent()
             expect(streamMessage.contentType).toBe(StreamMessage.CONTENT_TYPES.GROUP_KEY_ERROR_RESPONSE)

--- a/test/unit/MessageCreationUtil.test.js
+++ b/test/unit/MessageCreationUtil.test.js
@@ -376,7 +376,7 @@ describe('MessageCreationUtil', () => {
                 end: 2344155,
             })
 
-            expect(streamMessage.getStreamId()).toBe(getKeyExchangeStreamId('publisherId')) // sending to publisher's inbox stream
+            expect(streamMessage.getStreamId()).toBe(getKeyExchangeStreamId('publisherId')) // sending to publisher's keyexchange stream
             const content = streamMessage.getParsedContent()
             expect(streamMessage.contentType).toBe(StreamMessage.CONTENT_TYPES.GROUP_KEY_REQUEST)
             expect(streamMessage.encryptionType).toBe(StreamMessage.ENCRYPTION_TYPES.NONE)
@@ -443,7 +443,7 @@ describe('MessageCreationUtil', () => {
                 }]
             })
 
-            expect(streamMessage.getStreamId()).toBe(getKeyExchangeStreamId('subscriberId')) // sending to subscriber's inbox stream
+            expect(streamMessage.getStreamId()).toBe(getKeyExchangeStreamId('subscriberId')) // sending to subscriber's keyexchange stream
             const content = streamMessage.getParsedContent()
             expect(streamMessage.contentType).toBe(StreamMessage.CONTENT_TYPES.GROUP_KEY_RESPONSE_SIMPLE)
             expect(streamMessage.encryptionType).toBe(StreamMessage.ENCRYPTION_TYPES.RSA)
@@ -506,7 +506,7 @@ describe('MessageCreationUtil', () => {
                 requestId,
             })
 
-            expect(streamMessage.getStreamId()).toBe('destinationAddress') // sending to subscriber's inbox stream
+            expect(streamMessage.getStreamId()).toBe('destinationAddress') // sending to subscriber's keyexchange stream
 
             const content = streamMessage.getParsedContent()
             expect(streamMessage.contentType).toBe(StreamMessage.CONTENT_TYPES.GROUP_KEY_ERROR_RESPONSE)

--- a/test/unit/MessageCreationUtil.test.js
+++ b/test/unit/MessageCreationUtil.test.js
@@ -473,7 +473,7 @@ describe('MessageCreationUtil', () => {
             }), sinon.stub().resolves(stream))
 
             await util.createErrorMessage({
-                destinationAddress: 'destinationAddress',
+                keyExchangeStreamId: 'keyExchangeStreamId',
                 error: new Error(),
                 streamId: stream.id,
                 requestId: uniqueId('requestId'),
@@ -500,13 +500,13 @@ describe('MessageCreationUtil', () => {
 
             const requestId = uniqueId('requestId')
             const streamMessage = await util.createErrorMessage({
-                destinationAddress: 'destinationAddress',
+                keyExchangeStreamId: 'keyExchangeStreamId',
                 error: new InvalidGroupKeyRequestError('invalid'),
                 streamId: stream.id,
                 requestId,
             })
 
-            expect(streamMessage.getStreamId()).toBe('destinationAddress') // sending to subscriber's keyexchange stream
+            expect(streamMessage.getStreamId()).toBe('keyExchangeStreamId') // sending to subscriber's keyexchange stream
 
             const content = streamMessage.getParsedContent()
             expect(streamMessage.contentType).toBe(StreamMessage.CONTENT_TYPES.GROUP_KEY_ERROR_RESPONSE)

--- a/test/unit/MessageCreationUtil.test.js
+++ b/test/unit/MessageCreationUtil.test.js
@@ -30,7 +30,7 @@ describe('MessageCreationUtil', () => {
                     username: 'username',
                 }),
             }
-            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo())
+            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo)
             const publisherId = await msgCreationUtil.getPublisherId()
             expect(publisherId).toBe(wallet.address.toLowerCase())
         })
@@ -46,7 +46,7 @@ describe('MessageCreationUtil', () => {
                     username: 'username',
                 }),
             }
-            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo())
+            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo)
             const publisherId = await msgCreationUtil.getPublisherId()
             expect(publisherId).toBe(hashedUsername)
         })
@@ -62,7 +62,7 @@ describe('MessageCreationUtil', () => {
                     username: 'username',
                 }),
             }
-            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo())
+            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo)
             const publisherId = await msgCreationUtil.getPublisherId()
             expect(publisherId).toBe(hashedUsername)
         })
@@ -78,7 +78,7 @@ describe('MessageCreationUtil', () => {
                     username: 'username',
                 }),
             }
-            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo())
+            const msgCreationUtil = new MessageCreationUtil(client.options.auth, undefined, client.getUserInfo)
             const publisherId = await msgCreationUtil.getPublisherId()
             expect(publisherId).toBe(hashedUsername)
         })

--- a/test/unit/RealTimeSubscription.test.js
+++ b/test/unit/RealTimeSubscription.test.js
@@ -702,7 +702,6 @@ describe('RealTimeSubscription', () => {
     })
 
     describe('handleError()', () => {
-
         it('emits an error event', (done) => {
             const err = new Error('Test error')
             const sub = new RealTimeSubscription(

--- a/test/unit/RealTimeSubscription.test.js
+++ b/test/unit/RealTimeSubscription.test.js
@@ -1,6 +1,5 @@
 import crypto from 'crypto'
 
-import sinon from 'sinon'
 import { ControlLayer, MessageLayer, Errors } from 'streamr-client-protocol'
 
 import RealTimeSubscription from '../../src/RealTimeSubscription'

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -554,6 +554,7 @@ describe('StreamrClient', () => {
         })
 
         it('ignores messages for unknown Subscriptions', (done) => {
+            client.onError = jest.fn()
             sub.handleResentMessage = jest.fn()
 
             const msg1 = new UnicastMessage({
@@ -564,31 +565,29 @@ describe('StreamrClient', () => {
                 errors.pop() // remove this error
                 expect(err.message).toEqual(`Received unexpected UnicastMessage message ${msg1.serialize()}`)
                 expect(sub.handleResentMessage).not.toHaveBeenCalled()
+                expect(client.onError).toHaveBeenCalled()
                 done()
             })
 
             connection.emitMessage(msg1)
         })
 
-        it(
-            'should ensure that the promise returned by the verification function is cached',
-            (done) => {
-                const { requestId } = requests[requests.length - 1]
-                sub.handleResentMessage = (message, msgRequestId, verifyFn) => {
-                    expect(msgRequestId).toEqual(requestId)
-                    const firstResult = verifyFn()
-                    expect(firstResult).toBeInstanceOf(Promise)
-                    expect(firstResult).toBe(verifyFn())
-                    done()
-                }
-
-                const msg1 = new UnicastMessage({
-                    streamMessage: getStreamMessage(sub.streamId, {}),
-                    requestId,
-                })
-                connection.emitMessage(msg1)
+        it('should ensure that the promise returned by the verification function is cached', (done) => {
+            const { requestId } = requests[requests.length - 1]
+            sub.handleResentMessage = (message, msgRequestId, verifyFn) => {
+                expect(msgRequestId).toEqual(requestId)
+                const firstResult = verifyFn()
+                expect(firstResult).toBeInstanceOf(Promise)
+                expect(firstResult).toBe(verifyFn())
+                done()
             }
-        )
+
+            const msg1 = new UnicastMessage({
+                streamMessage: getStreamMessage(sub.streamId, {}),
+                requestId,
+            })
+            connection.emitMessage(msg1)
+        })
     })
 
     describe('ResendResponseResending', () => {
@@ -619,6 +618,7 @@ describe('StreamrClient', () => {
         })
 
         it('emits error when unknown request id', (done) => {
+            client.onError = jest.fn()
             sub.handleResending = jest.fn()
             const resendResponse = new ResendResponseResending({
                 streamId: sub.streamId,
@@ -628,6 +628,7 @@ describe('StreamrClient', () => {
             client.once('error', (err) => {
                 errors.pop() // remove this err
                 expect(err.message).toEqual(`Received unexpected ResendResponseResending message ${resendResponse.serialize()}`)
+                expect(client.onError).toHaveBeenCalled()
                 expect(sub.handleResending).not.toHaveBeenCalled()
                 done()
             })
@@ -661,6 +662,7 @@ describe('StreamrClient', () => {
         })
 
         it('ignores messages for unknown subscriptions', (done) => {
+            client.onError = jest.fn()
             sub.handleNoResend = jest.fn()
             const resendResponse = new ResendResponseNoResend({
                 streamId: sub.streamId,
@@ -671,6 +673,7 @@ describe('StreamrClient', () => {
                 errors.pop() // remove this err
                 expect(err.message).toEqual(`Received unexpected ResendResponseNoResend message ${resendResponse.serialize()}`)
                 expect(sub.handleNoResend).not.toHaveBeenCalled()
+                expect(client.onError).toHaveBeenCalled()
                 done()
             })
             connection.emitMessage(resendResponse)
@@ -703,6 +706,7 @@ describe('StreamrClient', () => {
         })
 
         it('does not call event handler for unknown subscriptions', (done) => {
+            client.onError = jest.fn()
             sub.handleResent = jest.fn()
             const resendResponse = new ResendResponseResent({
                 streamId: sub.streamId,
@@ -713,6 +717,7 @@ describe('StreamrClient', () => {
                 errors.pop() // remove this err
                 expect(err.message).toEqual(`Received unexpected ResendResponseResent message ${resendResponse.serialize()}`)
                 expect(sub.handleResent).not.toHaveBeenCalled()
+                expect(client.onError).toHaveBeenCalled()
                 done()
             })
             connection.emitMessage(resendResponse)
@@ -731,6 +736,7 @@ describe('StreamrClient', () => {
         })
 
         it('emits an error event on client', (done) => {
+            client.onError = jest.fn()
             const { requestId } = requests[requests.length - 1]
             const errorResponse = new ErrorResponse({
                 errorMessage: 'Test error',
@@ -741,7 +747,7 @@ describe('StreamrClient', () => {
             client.once('error', async (err) => {
                 errors.pop()
                 expect(err.message).toEqual(errorResponse.errorMessage)
-                await wait(100)
+                expect(client.onError).toHaveBeenCalled()
                 done()
             })
             connection.emitMessage(errorResponse)
@@ -766,21 +772,18 @@ describe('StreamrClient', () => {
 
             sub.handleError = async (err) => {
                 expect(err).toBe(jsonError)
-                await wait(100)
                 done()
             }
-            client.once('error', () => {
-                errors.pop()
-            })
             connection.emit('error', jsonError)
         })
 
         it('emits other errors as error events on client', (done) => {
+            client.onError = jest.fn()
             const testError = new Error('This is a test error message, ignore')
 
             client.once('error', async (err) => {
                 expect(err).toBe(testError)
-                await wait(100)
+                expect(client.onError).toHaveBeenCalled()
                 done()
             })
             client.once('error', () => {

--- a/test/unit/StreamrClient.test.js
+++ b/test/unit/StreamrClient.test.js
@@ -806,15 +806,33 @@ describe('StreamrClient', () => {
             expect(connection.connect).toHaveBeenCalledTimes(1)
         })
 
-        it('should reject promise while connecting', async () => {
+        it('should reject promise while connecting', async (done) => {
+            client.onError = jest.fn()
             connection.state = Connection.State.CONNECTING
+            client.once('error', (err) => {
+                errors.pop()
+                expect(err).toMatchObject({
+                    message: 'Already connecting!'
+                })
+                expect(client.onError).toHaveBeenCalledTimes(1)
+                done()
+            })
             await expect(() => (
                 client.connect()
             )).rejects.toThrow()
         })
 
-        it('should reject promise when connected', async () => {
+        it('should reject promise when connected', async (done) => {
+            client.onError = jest.fn()
             connection.state = Connection.State.CONNECTED
+            client.once('error', (err) => {
+                errors.pop()
+                expect(err).toMatchObject({
+                    message: 'Already connected!'
+                })
+                expect(client.onError).toHaveBeenCalledTimes(1)
+                done()
+            })
             await expect(() => (
                 client.connect()
             )).rejects.toThrow()

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon'
+import debugFactory from 'debug'
 
 import authFetch from '../../src/rest/authFetch'
 import { uuid } from '../../src/utils'
 
+const debug = debugFactory('StreamrClient::test::utils')
 const express = require('express')
 
 describe('utils', () => {
@@ -30,7 +32,7 @@ describe('utils', () => {
         expressApp.get(testUrl, (req, res) => handle(req, res))
 
         server = expressApp.listen(30000, () => {
-            console.info('Mock server started on port 30000\n') // eslint-disable-line no-console
+            debug('Mock server started on port 30000\n') // eslint-disable-line no-console
             done()
         })
     })


### PR DESCRIPTION
Error output is suppressed when expected. All errors should be caught, promises handled.

* No unhandledRejection errors, no "expected" error log messages.
* Prevents cases where the same error was logged twice.
* Log messages are prefixed/scoped to a client instance where possible.
* Added additional logging around http methods.
* Prevented proceeding blindly with inbox stream subscription if disconnected after connection.
* Stops background fetching of user info on `new Client`, only starts fetching if/when user first needs session info, which allows the error to be caught by this caller.

Doesn't fully fix everything, there are still errors that can fire in event handlers or setTimeout which have no way of being caught and handled properly yet.