### PR TITLE
5. Message Sequencing – Guarantee sequence follows publish order & Prevent backdated messages silently breaking future publishes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8526,6 +8526,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "pkg-dir": {
@@ -11427,6 +11438,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "strip-json-comments": {
@@ -12171,10 +12193,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+      "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -12186,6 +12207,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-map": {
@@ -12225,8 +12257,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pac-proxy-agent": {
       "version": "3.0.1",
@@ -15548,6 +15579,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "supports-color": {
@@ -15964,6 +16006,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "node-fetch": "^2.6.1",
     "node-webcrypto-ossl": "^2.1.1",
     "once": "^1.4.0",
+    "p-limit": "^3.0.2",
     "p-memoize": "^4.0.0",
     "promise-memoize": "^1.2.1",
     "qs": "^6.9.4",

--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch'
-import debugFactory from 'debug'
+import Debug from 'debug'
 
 import AuthFetchError from '../errors/AuthFetchError'
 import { getVersionString } from '../utils'
@@ -8,23 +8,30 @@ export const DEFAULT_HEADERS = {
     'Streamr-Client': `streamr-client-javascript/${getVersionString()}`,
 }
 
-const debug = debugFactory('StreamrClient:utils')
+const debug = Debug('StreamrClient:utils:authfetch')
 
-const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
+let ID = 0
+
+export default async function authFetch(url, session, opts, requireNewToken = false) {
+    ID += 1
+    const timeStart = Date.now()
+    const id = ID
+
     const options = {
         ...opts,
         headers: {
             ...DEFAULT_HEADERS,
-            ...opts.headers,
+            ...(opts && opts.headers),
         }
     }
+
     // add default 'Content-Type: application/json' header for all requests
     // including 0 body length POST calls
     if (!options.headers['Content-Type']) {
         options.headers['Content-Type'] = 'application/json'
     }
 
-    debug('authFetch: ', url, opts)
+    debug('%d %s >> %o', id, url, opts)
 
     const response = await fetch(url, {
         ...opts,
@@ -35,6 +42,8 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
             ...options.headers,
         },
     })
+    const timeEnd = Date.now()
+    debug('%d %s << %d %s %s %s', id, url, response.status, response.statusText, Debug.humanize(timeEnd - timeStart))
 
     const body = await response.text()
 
@@ -42,13 +51,14 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
         try {
             return JSON.parse(body || '{}')
         } catch (e) {
+            debug('%d %s – failed to parse body: %s', id, url, e.stack)
             throw new AuthFetchError(e.message, response, body)
         }
     } else if ([400, 401].includes(response.status) && !requireNewToken) {
+        debug('%d %s – revalidating session')
         return authFetch(url, session, options, true)
     } else {
-        throw new AuthFetchError(`Request to ${url} returned with error code ${response.status}.`, response, body)
+        debug('%d %s – failed', id, url)
+        throw new AuthFetchError(`Request ${id} to ${url} returned with error code ${response.status}.`, response, body)
     }
 }
-
-export default authFetch

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import uniqueId from 'lodash.uniqueid'
 import LRU from 'quick-lru'
 import pMemoize from 'p-memoize'
+import pLimit from 'p-limit'
 import mem from 'mem'
 
 import pkg from '../package.json'
@@ -40,12 +41,27 @@ export function waitFor(emitter, event) {
 }
 
 /* eslint-disable object-curly-newline */
-export function CacheAsyncFn(fn, {
+
+/**
+ * Returns a cached async fn, cached keyed on first argument passed. See documentation for mem/p-memoize.
+ * Caches into a LRU cache capped at options.maxSize
+ * Won't call asyncFn again until options.maxAge or options.maxSize exceeded, or cachedAsyncFn.clear() is called.
+ * Won't cache rejections by default. Override with options.cachePromiseRejection = true.
+ *
+ * ```js
+ * const cachedAsyncFn = CacheAsyncFn(asyncFn, options)
+ * await cachedAsyncFn(key)
+ * await cachedAsyncFn(key)
+ * cachedAsyncFn.clear()
+ * ```
+ */
+
+export function CacheAsyncFn(asyncFn, {
     maxSize = 10000,
     maxAge = 30 * 60 * 1000, // 30 minutes
     cachePromiseRejection = false,
 } = {}) {
-    const cachedFn = pMemoize(fn, {
+    const cachedFn = pMemoize(asyncFn, {
         maxAge,
         cachePromiseRejection,
         cache: new LRU({
@@ -55,6 +71,20 @@ export function CacheAsyncFn(fn, {
     cachedFn.clear = () => pMemoize.clear(cachedFn)
     return cachedFn
 }
+
+/**
+ * Returns a cached fn, cached keyed on first argument passed. See documentation for mem.
+ * Caches into a LRU cache capped at options.maxSize
+ * Won't call fn again until options.maxAge or options.maxSize exceeded, or cachedFn.clear() is called.
+ *
+ * ```js
+ * const cachedFn = CacheFn(fn, options)
+ * cachedFn(key)
+ * cachedFn(key)
+ * cachedFn(...args)
+ * cachedFn.clear()
+ * ```
+ */
 
 export function CacheFn(fn, {
     maxSize = 10000,
@@ -69,4 +99,38 @@ export function CacheFn(fn, {
     cachedFn.clear = () => mem.clear(cachedFn)
     return cachedFn
 }
+
 /* eslint-enable object-curly-newline */
+
+/**
+ * Returns a limit function that limits concurrency per-key.
+ *
+ * ```js
+ * const limit = LimitAsyncFnByKey(1)
+ * limit('channel1', fn)
+ * limit('channel2', fn)
+ * limit('channel2', fn)
+ * ```
+ */
+
+export function LimitAsyncFnByKey(limit) {
+    const pending = new Map()
+    const f = async (id, fn) => {
+        const limitFn = pending.get(id) || pending.set(id, pLimit(limit)).get(id)
+        try {
+            return await limitFn(fn)
+        } finally {
+            if (!limitFn.activeCount && !limitFn.pendingCount && pending.get(id) === limitFn) {
+                // clean up if no more active entries (if not cleared)
+                pending.delete(id)
+            }
+        }
+    }
+    f.clear = () => {
+        // note: does not cancel promises
+        pending.forEach((p) => p.clearQueue())
+        pending.clear()
+    }
+    return f
+}
+

--- a/test/integration/Sequencing.test.js
+++ b/test/integration/Sequencing.test.js
@@ -1,0 +1,290 @@
+import { wait, waitForCondition, waitForEvent } from 'streamr-test-utils'
+
+import { uid, fakePrivateKey } from '../utils'
+import StreamrClient from '../../src'
+import Connection from '../../src/Connection'
+
+import config from './config'
+
+const Msg = (opts) => ({
+    value: uid('msg'),
+    ...opts,
+})
+
+function toSeq(requests, ts = Date.now()) {
+    return requests.map((m) => {
+        const { prevMsgRef } = m.streamMessage
+        return [
+            [m.streamMessage.getTimestamp() - ts, m.streamMessage.getSequenceNumber()],
+            prevMsgRef ? [prevMsgRef.timestamp - ts, prevMsgRef.sequenceNumber] : null
+        ]
+    })
+}
+
+describe('Sequencing', () => {
+    let expectErrors = 0 // check no errors by default
+    let onError = jest.fn()
+    let client
+    let stream
+
+    const createClient = (opts = {}) => {
+        const c = new StreamrClient({
+            auth: {
+                privateKey: fakePrivateKey(),
+            },
+            autoConnect: false,
+            autoDisconnect: false,
+            maxRetries: 2,
+            ...config.clientOptions,
+            ...opts,
+        })
+        c.onError = jest.fn()
+        c.on('error', onError)
+        return c
+    }
+
+    beforeEach(async () => {
+        expectErrors = 0
+        onError = jest.fn()
+        client = createClient()
+        await client.connect()
+
+        stream = await client.createStream({
+            name: uid('stream')
+        })
+    })
+
+    afterEach(async () => {
+        await wait()
+        // ensure no unexpected errors
+        expect(onError).toHaveBeenCalledTimes(expectErrors)
+        if (client) {
+            expect(client.onError).toHaveBeenCalledTimes(expectErrors)
+        }
+    })
+
+    afterEach(async () => {
+        await wait()
+        if (client) {
+            client.debug('disconnecting after test')
+            await client.disconnect()
+        }
+
+        const openSockets = Connection.getOpen()
+        if (openSockets !== 0) {
+            throw new Error(`sockets not closed: ${openSockets}`)
+        }
+    })
+
+    it('should sequence in order', async () => {
+        const ts = Date.now()
+        const msgsPublished = []
+        const msgsReceieved = []
+
+        await client.subscribe(stream.id, (m) => msgsReceieved.push(m))
+
+        const nextMsg = () => {
+            const msg = Msg()
+            msgsPublished.push(msg)
+            return msg
+        }
+
+        const requests = await Promise.all([
+            // first 2 messages at ts + 0
+            client.publish(stream, nextMsg(), ts),
+            client.publish(stream, nextMsg(), ts),
+            // next two messages at ts + 1
+            client.publish(stream, nextMsg(), ts + 1),
+            client.publish(stream, nextMsg(), ts + 1),
+        ])
+        const seq = toSeq(requests, ts)
+        expect(seq).toEqual([
+            [[0, 0], null],
+            [[0, 1], [0, 0]],
+            [[1, 0], [0, 1]],
+            [[1, 1], [1, 0]],
+        ])
+
+        await waitForCondition(() => (
+            msgsReceieved.length === msgsPublished.length
+        ), 5000).catch(() => {}) // ignore, tests will fail anyway
+
+        expect(msgsReceieved).toEqual(msgsPublished)
+    }, 10000)
+
+    it('should sequence in order even if some calls delayed', async () => {
+        const ts = Date.now()
+        const msgsPublished = []
+        const msgsReceieved = []
+
+        let calls = 0
+        const { clear } = client.publisher.msgCreationUtil.getPublisherId
+        const getPublisherId = client.publisher.msgCreationUtil.getPublisherId.bind(client.publisher.msgCreationUtil)
+        client.publisher.msgCreationUtil.getPublisherId = async (...args) => {
+            // delay getPublisher call
+            calls += 1
+            if (calls === 2) {
+                const result = await getPublisherId(...args)
+                // delay resolving this call
+                await wait(100)
+                return result
+            }
+            return getPublisherId(...args)
+        }
+        client.publisher.msgCreationUtil.getPublisherId.clear = clear
+
+        const nextMsg = () => {
+            const msg = Msg()
+            msgsPublished.push(msg)
+            return msg
+        }
+
+        await client.subscribe(stream.id, (m) => msgsReceieved.push(m))
+        const requests = await Promise.all([
+            // first 2 messages at ts + 0
+            client.publish(stream, nextMsg(), ts),
+            client.publish(stream, nextMsg(), ts),
+            // next two messages at ts + 1
+            client.publish(stream, nextMsg(), ts + 1),
+            client.publish(stream, nextMsg(), ts + 1),
+        ])
+        const seq = toSeq(requests, ts)
+        expect(seq).toEqual([
+            [[0, 0], null],
+            [[0, 1], [0, 0]],
+            [[1, 0], [0, 1]],
+            [[1, 1], [1, 0]],
+        ])
+
+        await waitForCondition(() => (
+            msgsReceieved.length === msgsPublished.length
+        ), 5000).catch(() => {}) // ignore, tests will fail anyway
+
+        expect(msgsReceieved).toEqual(msgsPublished)
+    }, 10000)
+
+    it('should sequence in order even if publish requests backdated', async () => {
+        const ts = Date.now()
+        const msgsPublished = []
+        const msgsReceieved = []
+
+        await client.subscribe(stream.id, (m) => msgsReceieved.push(m))
+
+        const nextMsg = (...args) => {
+            const msg = Msg(...args)
+            msgsPublished.push(msg)
+            return msg
+        }
+
+        const requests = await Promise.all([
+            // publish at ts + 0
+            client.publish(stream, nextMsg(), ts),
+            // publish at ts + 1
+            client.publish(stream, nextMsg(), ts + 1),
+            // backdate at ts + 0
+            client.publish(stream, nextMsg({
+                backdated: true,
+            }), ts),
+            // resume at ts + 2
+            client.publish(stream, nextMsg(), ts + 2),
+            client.publish(stream, nextMsg(), ts + 2),
+            client.publish(stream, nextMsg(), ts + 3),
+        ])
+
+        await waitForCondition(() => (
+            msgsReceieved.length === msgsPublished.length
+        ), 2000).catch(() => {}) // ignore, tests will fail anyway
+
+        const msgsResent = []
+        const sub = await client.resend({
+            stream: stream.id,
+            resend: {
+                from: {
+                    timestamp: 0
+                },
+            },
+        }, (m) => msgsResent.push(m))
+        await waitForEvent(sub, 'resent')
+
+        expect(msgsReceieved).toEqual(msgsResent)
+        // backdated messages disappear
+        expect(msgsReceieved).toEqual(msgsPublished.filter(({ backdated }) => !backdated))
+
+        const seq = toSeq(requests, ts)
+        client.debug(seq)
+        expect(seq).toEqual([
+            [[0, 0], null],
+            [[1, 0], [0, 0]],
+            [[0, 0], [1, 0]], // bad message
+            [[2, 0], [1, 0]],
+            [[2, 1], [2, 0]],
+            [[3, 0], [2, 1]],
+        ])
+    }, 10000)
+
+    it('should sequence in order even if publish requests backdated in sequence', async () => {
+        const ts = Date.now()
+        const msgsPublished = []
+        const msgsReceieved = []
+
+        await client.subscribe(stream.id, (m) => msgsReceieved.push(m))
+
+        const nextMsg = (...args) => {
+            const msg = Msg(...args)
+            msgsPublished.push(msg)
+            return msg
+        }
+
+        const requests = await Promise.all([
+            // first 3 messages at ts + 0
+            client.publish(stream, nextMsg(), ts),
+            client.publish(stream, nextMsg(), ts),
+            client.publish(stream, nextMsg(), ts),
+            // next two messages at ts + 1
+            client.publish(stream, nextMsg(), ts + 1),
+            client.publish(stream, nextMsg(), ts + 1),
+            // backdate at ts + 0
+            client.publish(stream, nextMsg({
+                backdated: true,
+            }), ts),
+            // resume publishing at ts + 1
+            client.publish(stream, nextMsg(), ts + 1),
+            client.publish(stream, nextMsg(), ts + 1),
+            client.publish(stream, nextMsg(), ts + 2),
+            client.publish(stream, nextMsg(), ts + 2),
+        ])
+
+        await waitForCondition(() => (
+            msgsReceieved.length === msgsPublished.length
+        ), 2000).catch(() => {}) // ignore, tests will fail anyway
+
+        const msgsResent = []
+        const sub = await client.resend({
+            stream: stream.id,
+            resend: {
+                from: {
+                    timestamp: 0
+                },
+            },
+        }, (m) => msgsResent.push(m))
+        await waitForEvent(sub, 'resent')
+
+        expect(msgsReceieved).toEqual(msgsResent)
+        // backdated messages disappear
+        expect(msgsReceieved).toEqual(msgsPublished.filter(({ backdated }) => !backdated))
+
+        const seq = toSeq(requests, ts)
+        expect(seq).toEqual([
+            [[0, 0], null],
+            [[0, 1], [0, 0]],
+            [[0, 2], [0, 1]],
+            [[1, 0], [0, 2]],
+            [[1, 1], [1, 0]],
+            [[0, 0], [1, 1]], // bad message
+            [[1, 2], [1, 1]],
+            [[1, 3], [1, 2]],
+            [[2, 0], [1, 3]],
+            [[2, 1], [2, 0]],
+        ])
+    }, 10000)
+})

--- a/test/unit/MessageCreationUtil.test.js
+++ b/test/unit/MessageCreationUtil.test.js
@@ -232,7 +232,7 @@ describe('MessageCreationUtil', () => {
                 content: pubMsg, timestamp: ts,
             })
             const sequenceNumbers = [streamMessage1, streamMessage2, streamMessage3].map((m) => m.getSequenceNumber())
-            expect(sequenceNumbers).toEqual([0, 0, 1])
+            expect(sequenceNumbers).toEqual([0, 0, 0])
         })
 
         it('should publish messages with sequence number 0 (different streams)', async () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -53,8 +53,8 @@ describe('utils', () => {
             session.getSessionToken = sinon.stub().resolves('invalid token')
             return authFetch(baseUrl + testUrl, session).catch((err) => {
                 expect(session.getSessionToken.calledTwice).toBeTruthy()
-                expect(err.toString()).toEqual(
-                    `Error: Request to ${baseUrl + testUrl} returned with error code 401. Unauthorized`
+                expect(err.toString()).toMatch(
+                    `${baseUrl + testUrl} returned with error code 401. Unauthorized`
                 )
                 expect(err.body).toEqual('Unauthorized')
                 done()


### PR DESCRIPTION
This fixes two edge-case issues with sequences & publishing, both of which result in silent/subtle issues, so they may or may not affect existing streams and just haven't been noticed.

## Problem 1: Backdated messages corrupt sequencing

Publishing back-dated (i.e. non-sequentially timestamped) messages will break sequencing. This could happen if the user publishes old data with a custom timestamp using the same client instance + stream that they're publishing realtime data to i.e. same message chain.

This happens because we lose track of biggest sequence number whenever the timestamp changes for stream id+partition combo, there's an assumption that if the timestamp changes, then the new timestamp is actually newer, but this isn't verified in the client. Backdated messages then start at sequence 0 again, regardless of the sequencing of existing messages. And the prevMessageRef of these backdated messages will point into future.

e.g. consider this publish sequence, where [timestamp, sequence] -> prevMessageRef,

```
[0, 0] -> null
[0, 1] -> [0, 0]
[0, 2] -> [0, 1]
[1, 0] -> [0, 2]
```

Then you publish a new message with timestamp 0, and then a new message with timestamp 1:

```
[0, 0] -> null (clobbered?)
[0, 0] -> [1, 0] (new)
[0, 1] -> [0, 0]
[0, 2] -> [0, 1]
[1, 0] -> [0, 2] (clobbered?)
[1, 0] -> [0, 0] (new)
```

Were these messages to be accepted by the network, since it considers a timestamp+sequence number unique, the newer messages occurring with the same timestamp + sequence number would clobber the older messages, while also having a a messed up future-dated & cyclic `prevMessageRef` 🤢 

Thankfully this doesn't seem to happen, currently backdated messages seem to simply disappear from the client's perspective. The backdated messages aren't sent into a stream's subscription, nor are they resent. Unfortunately, all future publishes to this stream also seem to disappear. Only messages before the first backdated message survive.

The backend seems to be responsible for the disappearing behaviour. No error messages appear in the logs on publish, though resends on bad streams do report:

```
WARN  (streamr:logic:node:0xde3331cA6B8B636E0b82Bf08E941F727B8927442/1 on 3538effb88a9): 
pre-condition: gap overlap in given numbers: previousNumber=1600712118432|0, number=1600712118434|0, state=(1600712118433|0, Infinity|Infinity]
```

Not sure a good way around this other than blocking backdated messages on the same chain. Should probably enforce this in the protocol e.g. `StreamMessage` constructor could error on a `prevMessageRef` with a timestamp greater than their current timestamp. Would also be good if the backend would send some information to the client when such things occur. I found a partial workaround that at least keeps non-backdated publishing working (see below).

We could keep a single global sequence counter for a stream, this would prevent duplicate timestamp + sequence number entries from occurring, and keep everything sortable, but doesn't prevent `prevMessageRef` from pointing into the future.

Should probably figure out and document an official way to safely publish backdated messages e.g. publishing archived data. Sequencing should be fine so long as the backdated messages end up on a different message chain. Currently this requires using a different client instance. Perhaps we could add a new method to the client like: 

```js
const newChainClient = client.createNewChain()
await newChainClient.publish(oldData)
```

or something else specifically for this use-case.


#### Partial Workaround

https://github.com/streamr-dev/streamr-client-javascript/blob/e2fcccce27a20d01af55d4569fbb601a05534987/src/Publisher.js#L68-L70

I've added a partial workaround for backdated messages silently breaking sequencing by ignoring updates to the latest sequence number/timestamp if the timestamp is older than the previous message timestamp. Without this *all published messages after the backdated message will just silently disappear*. With this change, backdated messages still get sent to the network and silently disappear, but at least the "properly" sequenced messages will continue to work. Not good but better.

```
[0, 0] -> null
[0, 1] -> [0, 0]
[0, 2] -> [0, 1]
[1, 0] -> [0, 2]
[0, 0] -> [1, 0] (backdated, ignored)
[1, 1] -> [1, 0] (workaround allows this to work, without workaround this would be ignored)
```

#### Possible alternative workaround

Another option could be to automatically start a new chain when it detects stuff out of order. Using same example as before, if after publishing a message at timestamp 1, you publish new messages at timestamp 0, and then another at 1, it creates a new chain on the first backdated message, which prevents the backdated message from being lost:

```
[0, 0] -> null
[0, 1] -> [0, 0]
[0, 2] -> [0, 1]
[1, 0] -> [0, 2]
// new chain
[0, 0] -> null // backdated
[1, 0] -> [0, 2]
```

This results in inconsistent message sequencing on a realtime subscription, but seems to produce reliable sequencing for resends. **The upside of this method is that no data is lost**, and user doesn't have to explicitly opt-into thinking about message chains. The downside is that it adds breaks into the chain, resulting in less reliable ordering.

Another option could be to remove the ability to have user-supplied timestamps altogether, if users need to sort they can add their own timestamp field into the message body. This makes the timestamp explicitly refer to "publish time", rather than anything about the data's time, which is probably the intended purpose anyway.

## Problem 2: Sequencing occurs after unsequenced async calls:

A number of async calls are made before the message is sequenced, specifically:
1. Fetch publisher id (loads username from server)
2. Fetch stream partitions (loads stream info from server)

If something causes the timing in these async functions to resolve in a different order than they were issued, then the sequencing will be applied out-of-order. Both of the above calls are cached remote calls, so in practice this should never occur but a bug here is very subtle, may only occur under certain circumstances, leads to only slightly corrupt data, so likely it would go undetected.

I've added a few tests which catch this type of bug going forward, and fixed the publishing code to guarantee the async calls always resolve in the same order they were issued, thus publish call-order sequencing is guaranteed by pushing these async calls into a per-stream queue:

https://github.com/streamr-dev/streamr-client-javascript/blob/e2fcccce27a20d01af55d4569fbb601a05534987/src/Publisher.js#L222-L237

----

Builds on:

* Split Client into Publisher/Subscriber/Resender #156
* Connection/Reconnection Refactoring #160
* Publish/Subscribe Promisification #162
* Publish Refactor/Simplify #164