### PR TITLE
Only add Content-Type header for POST and PUT

### DIFF
--- a/src/rest/authFetch.js
+++ b/src/rest/authFetch.js
@@ -18,9 +18,8 @@ const authFetch = async (url, session, opts = {}, requireNewToken = false) => {
             ...opts.headers,
         }
     }
-    // add default 'Content-Type: application/json' header for all requests
-    // including 0 body length POST calls
-    if (!options.headers['Content-Type']) {
+    // add default 'Content-Type: application/json' header for all POST and PUT requests
+    if (!options.headers['Content-Type'] && (options.method === 'POST' || options.method === 'PUT')) {
         options.headers['Content-Type'] = 'application/json'
     }
 

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -70,6 +70,27 @@ describe('StreamEndpoints', () => {
         })
     })
 
+    describe('listStreams', () => {
+        it('filters by given criteria (match)', async () => {
+            const stream = await client.createStream({
+                name: `StreamEndpoints-integration-${Date.now()}`,
+            })
+
+            const result = await client.listStreams({
+                name: stream.name,
+            })
+            assert.strictEqual(result.length, 1)
+            assert.strictEqual(result[0].id, stream.id)
+        })
+
+        it('filters by given criteria (no  match)', async () => {
+            const result = await client.listStreams({
+                name: `non-existent-${Date.now()}`,
+            })
+            assert.strictEqual(result.length, 0)
+        })
+    })
+
     describe('getStreamPublishers', () => {
         it('retrieves a list of publishers', async () => {
             const publishers = await client.getStreamPublishers(createdStream.id)

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -33,8 +33,8 @@ describe('StreamEndpoints', () => {
         })
     })
 
-    describe('Stream creation', () => {
-        it('createStream', async () => {
+    describe('createStream', () => {
+        it('creates a stream with correct values', async () => {
             const stream = await client.createStream({
                 name,
                 requireSignedData: true,
@@ -42,25 +42,31 @@ describe('StreamEndpoints', () => {
             })
             createdStream = stream
             assert(createdStream.id)
-            assert.equal(createdStream.name, name)
+            assert.strictEqual(createdStream.name, name)
             assert.strictEqual(createdStream.requireSignedData, true)
         })
+    })
 
+    describe('getOrCreate', () => {
         it('getOrCreate an existing Stream', async () => {
-            const existingStream = await client.getOrCreateStream({
-                name,
+            const stream = await client.createStream({
+                name: `StreamEndpoints-integration-${Date.now()}`,
             })
-            assert.equal(existingStream.id, createdStream.id)
-            assert.equal(existingStream.name, createdStream.name)
+
+            const existingStream = await client.getOrCreateStream({
+                name: stream.name,
+            })
+            assert.strictEqual(existingStream.id, stream.id)
+            assert.strictEqual(existingStream.name, stream.name)
         })
 
-        it.skip('getOrCreate a new Stream', async () => {
-            const newName = Date.now().toString()
+        it('getOrCreate a new Stream', async () => {
+            const newName = `StreamEndpoints-integration-${Date.now()}`
             const newStream = await client.getOrCreateStream({
                 name: newName,
             })
 
-            assert.notEqual(newStream.id, createdStream.id)
+            assert.strictEqual(newStream.name, newName)
         })
     })
 
@@ -126,7 +132,7 @@ describe('StreamEndpoints', () => {
             // Need time to propagate to storage
             await wait(10000)
             const stream = await createdStream.detectFields()
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 stream.config.fields,
                 [
                     {
@@ -147,7 +153,7 @@ describe('StreamEndpoints', () => {
         it('Stream.getPermissions', async () => {
             const permissions = await createdStream.getPermissions()
             // get, edit, delete, subscribe, publish, share
-            assert.equal(permissions.length, 6, `Unexpected number of permissions: ${JSON.stringify(permissions)}`)
+            assert.strictEqual(permissions.length, 6, `Unexpected number of permissions: ${JSON.stringify(permissions)}`)
         })
 
         it('Stream.hasPermission', async () => {
@@ -169,7 +175,7 @@ describe('StreamEndpoints', () => {
     describe('Stream deletion', () => {
         it('Stream.delete', async () => {
             await createdStream.delete()
-            assert.rejects(async () => {
+            await assert.rejects(async () => {
                 await client.getStream(createdStream.id)
             })
         })


### PR DESCRIPTION
Previous code lead to query params being ignored on `GET` requests. 

While the backend would ideally be more tolerant to "abuse", it's harder to fix on that end because Grails conforms to certain conventions which are hard to customize. 

The RFC is unclear about whether it's wrong to add `Content-Type` to requests that can't even have a body, but in any case I don't think we should add headers that have _no chance of doing anything except perhaps throwing off the backend_.

One thing that would fail for example was:

```
client.listStreams({
    name: 'foo'
})
```

The above is expected to return an empty list, if the user doesn't have a stream named `foo`. However, it currently returns ALL streams which the user can access, because the filter criteria is passed as query params (as per API spec) and gets ignored.

There was an integration test that would have caught this, but it had been skipped. :( This PR fixes the issue and adds the test back in.