### PR TITLE
NET-60: Use REST API via Nginx

### DIFF
--- a/examples/web/web-example-metamask.html
+++ b/examples/web/web-example-metamask.html
@@ -15,7 +15,7 @@
 
         // Create the client and give the current Ethereum provider. The login function is created but not called.
         const client = new StreamrClient({
-            restUrl: 'http://localhost:8081/streamr-core/api/v1',
+            restUrl: 'http://localhost/api/v1',
             auth: {
                 provider: web3.currentProvider,
             }

--- a/test/browser/browser.html
+++ b/test/browser/browser.html
@@ -12,7 +12,7 @@
             apiKey: 'tester1-api-key'
         },
         url: 'ws://localhost/api/v1/ws',
-        restUrl: 'http://localhost:8081/streamr-core/api/v1',
+        restUrl: 'http://localhost/api/v1',
         autoConnect: false,
         autoDisconnect: false
     })

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -1,7 +1,7 @@
 module.exports = {
     clientOptions: {
         url: process.env.WEBSOCKET_URL || 'ws://localhost/api/v1/ws',
-        restUrl: process.env.REST_URL || 'http://localhost:8081/streamr-core/api/v1',
+        restUrl: process.env.REST_URL || 'http://localhost/api/v1',
         tokenAddress: process.env.TOKEN_ADDRESS || '0xbAA81A0179015bE47Ad439566374F2Bae098686F',
         streamrNodeAddress: process.env.STREAMR_NODE_ADDRESS || '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
         streamrOperatorAddress: process.env.OPERATOR_ADDRESS || '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1',


### PR DESCRIPTION
Modify REST API url config for tests and examples. REST API is locally available at http://localhost/api/v1 if we use stream-docker-dev stack.