### PR TITLE
NET-61: Encode URL path parameters

### DIFF
--- a/src/rest/DataUnionEndpoints.js
+++ b/src/rest/DataUnionEndpoints.js
@@ -19,10 +19,9 @@ import {
     utils as ethersUtils,
 } from 'ethers'
 import debugFactory from 'debug'
-
 import * as DataUnion from '../../contracts/DataUnion.json'
-
 import authFetch, { DEFAULT_HEADERS } from './authFetch'
+import { getEndpointUrl }  from '../utils'
 
 const { computeAddress, getAddress } = ethersUtils
 
@@ -53,7 +52,7 @@ function sleep(ms) {
 }
 
 async function get(client, dataUnionContractAddress, endpoint, opts = {}) {
-    const url = `${client.options.restUrl}/communities/${dataUnionContractAddress}${endpoint}`
+    const url = getEndpointUrl(client.options.restUrl, 'communities', dataUnionContractAddress) + endpoint
     const response = await fetch(url, {
         ...opts,
         headers: {
@@ -194,7 +193,7 @@ export async function dataUnionIsReady(dataUnionContractAddress, pollingInterval
  * @param {String} name describes the secret
  */
 export async function createSecret(dataUnionContractAddress, secret, name = 'Untitled Data Union Secret') {
-    const url = `${this.options.restUrl}/communities/${dataUnionContractAddress}/secrets`
+    const url = getEndpointUrl(this.options.restUrl, 'communities', dataUnionContractAddress, 'secrets')
     return authFetch(
         url,
         this.session,
@@ -231,7 +230,7 @@ export async function joinDataUnion(dataUnionContractAddress, secret) {
     }
     if (secret) { body.secret = secret }
 
-    const url = `${this.options.restUrl}/communities/${dataUnionContractAddress}/joinRequests`
+    const url = getEndpointUrl(this.options.restUrl, 'communities', dataUnionContractAddress, 'joinRequests')
     return authFetch(
         url,
         this.session,

--- a/src/rest/DataUnionEndpoints.js
+++ b/src/rest/DataUnionEndpoints.js
@@ -19,9 +19,11 @@ import {
     utils as ethersUtils,
 } from 'ethers'
 import debugFactory from 'debug'
+
 import * as DataUnion from '../../contracts/DataUnion.json'
+import { getEndpointUrl } from '../utils'
+
 import authFetch, { DEFAULT_HEADERS } from './authFetch'
-import { getEndpointUrl }  from '../utils'
 
 const { computeAddress, getAddress } = ethersUtils
 

--- a/src/rest/LoginEndpoints.js
+++ b/src/rest/LoginEndpoints.js
@@ -1,4 +1,5 @@
 import authFetch from './authFetch'
+import { getEndpointUrl } from '../utils'
 
 async function getSessionToken(url, props) {
     return authFetch(
@@ -18,7 +19,7 @@ export async function getChallenge(address) {
     this.debug('getChallenge', {
         address,
     })
-    const url = `${this.options.restUrl}/login/challenge/${address}`
+    const url = getEndpointUrl(this.options.restUrl, 'login', 'challenge', address)
     return authFetch(
         url,
         undefined,
@@ -34,7 +35,7 @@ export async function sendChallengeResponse(challenge, signature, address) {
         signature,
         address,
     })
-    const url = `${this.options.restUrl}/login/response`
+    const url = getEndpointUrl(this.options.restUrl, 'login', 'response')
     const props = {
         challenge,
         signature,
@@ -56,7 +57,7 @@ export async function loginWithApiKey(apiKey) {
     this.debug('loginWithApiKey', {
         apiKey,
     })
-    const url = `${this.options.restUrl}/login/apikey`
+    const url = getEndpointUrl(this.options.restUrl, 'login', 'apikey')
     const props = {
         apiKey,
     }
@@ -67,7 +68,7 @@ export async function loginWithUsernamePassword(username, password) {
     this.debug('loginWithUsernamePassword', {
         username,
     })
-    const url = `${this.options.restUrl}/login/password`
+    const url = getEndpointUrl(this.options.restUrl, 'login', 'password')
     const props = {
         username,
         password,

--- a/src/rest/LoginEndpoints.js
+++ b/src/rest/LoginEndpoints.js
@@ -1,5 +1,6 @@
-import authFetch from './authFetch'
 import { getEndpointUrl } from '../utils'
+
+import authFetch from './authFetch'
 
 async function getSessionToken(url, props) {
     return authFetch(

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -6,6 +6,7 @@ import debugFactory from 'debug'
 
 import Stream from './domain/Stream'
 import authFetch from './authFetch'
+import { getEndpointUrl }  from '../utils'
 
 const debug = debugFactory('StreamrClient')
 
@@ -37,7 +38,7 @@ export async function getStream(streamId) {
     this.debug('getStream', {
         streamId,
     })
-    const url = `${this.options.restUrl}/streams/${streamId}`
+    const url = getEndpointUrl(this.options.restUrl, 'streams', streamId)
     const json = await authFetch(url, this.session)
     return json ? new Stream(this, json) : undefined
 }
@@ -46,7 +47,7 @@ export async function listStreams(query = {}) {
     this.debug('listStreams', {
         query,
     })
-    const url = `${this.options.restUrl}/streams?${qs.stringify(query)}`
+    const url = getEndpointUrl(this.options.restUrl, 'streams') + '?' + qs.stringify(query)
     const json = await authFetch(url, this.session)
     return json ? json.map((stream) => new Stream(this, stream)) : []
 }
@@ -112,7 +113,7 @@ export async function getStreamPublishers(streamId) {
     this.debug('getStreamPublishers', {
         streamId,
     })
-    const url = `${this.options.restUrl}/streams/${streamId}/publishers`
+    const url = getEndpointUrl(this.options.restUrl, 'streams', streamId, 'publishers')
     const json = await authFetch(url, this.session)
     return json.addresses.map((a) => a.toLowerCase())
 }
@@ -122,7 +123,7 @@ export async function isStreamPublisher(streamId, ethAddress) {
         streamId,
         ethAddress,
     })
-    const url = `${this.options.restUrl}/streams/${streamId}/publisher/${ethAddress}`
+    const url = getEndpointUrl(this.options.restUrl, 'streams', streamId, 'publisher', ethAddress)
     try {
         await authFetch(url, this.session)
         return true
@@ -138,7 +139,7 @@ export async function getStreamSubscribers(streamId) {
     this.debug('getStreamSubscribers', {
         streamId,
     })
-    const url = `${this.options.restUrl}/streams/${streamId}/subscribers`
+    const url = getEndpointUrl(this.options.restUrl, 'streams', streamId, 'subscribers')
     const json = await authFetch(url, this.session)
     return json.addresses.map((a) => a.toLowerCase())
 }
@@ -148,7 +149,7 @@ export async function isStreamSubscriber(streamId, ethAddress) {
         streamId,
         ethAddress,
     })
-    const url = `${this.options.restUrl}/streams/${streamId}/subscriber/${ethAddress}`
+    const url = getEndpointUrl(this.options.restUrl, 'streams', streamId, 'subscriber', ethAddress)
     try {
         await authFetch(url, this.session)
         return true
@@ -164,7 +165,7 @@ export async function getStreamValidationInfo(streamId) {
     this.debug('getStreamValidationInfo', {
         streamId,
     })
-    const url = `${this.options.restUrl}/streams/${streamId}/validation`
+    const url = getEndpointUrl(this.options.restUrl, 'streams', streamId, 'validation')
     const json = await authFetch(url, this.session)
     return json
 }

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -4,9 +4,10 @@ import { Agent as HttpsAgent } from 'https'
 import qs from 'qs'
 import debugFactory from 'debug'
 
+import { getEndpointUrl } from '../utils'
+
 import Stream from './domain/Stream'
 import authFetch from './authFetch'
-import { getEndpointUrl }  from '../utils'
 
 const debug = debugFactory('StreamrClient')
 

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -1,5 +1,5 @@
+import { getEndpointUrl } from '../../utils'
 import authFetch from '../authFetch'
-import { getEndpointUrl }  from '../../utils'
 
 export default class Stream {
     constructor(client, props) {

--- a/src/rest/domain/Stream.js
+++ b/src/rest/domain/Stream.js
@@ -1,4 +1,5 @@
 import authFetch from '../authFetch'
+import { getEndpointUrl }  from '../../utils'
 
 export default class Stream {
     constructor(client, props) {
@@ -8,7 +9,7 @@ export default class Stream {
 
     async update() {
         const json = await authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id),
             this._client.session,
             {
                 method: 'PUT',
@@ -30,7 +31,7 @@ export default class Stream {
 
     async delete() {
         return authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id),
             this._client.session,
             {
                 method: 'DELETE',
@@ -40,14 +41,14 @@ export default class Stream {
 
     async getPermissions() {
         return authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}/permissions`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id, 'permissions'),
             this._client.session,
         )
     }
 
     async getMyPermissions() {
         return authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}/permissions/me`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id, 'permissions', 'me'),
             this._client.session,
         )
     }
@@ -82,7 +83,7 @@ export default class Stream {
         }
 
         return authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}/permissions`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id, 'permissions'),
             this._client.session,
             {
                 method: 'POST',
@@ -93,7 +94,7 @@ export default class Stream {
 
     async revokePermission(permissionId) {
         return authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}/permissions/${permissionId}`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id, 'permissions', permissionId),
             this._client.session,
             {
                 method: 'DELETE',
@@ -103,7 +104,7 @@ export default class Stream {
 
     async detectFields() {
         return authFetch(
-            `${this._client.options.restUrl}/streams/${this.id}/detectFields`,
+            getEndpointUrl(this._client.options.restUrl, 'streams', this.id, 'detectFields'),
             this._client.session,
         )
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,5 +37,5 @@ export function waitFor(emitter, event) {
 }
 
 export const getEndpointUrl = (baseUrl, ...pathParts) => {
-	return baseUrl + '/' + pathParts.map(part => encodeURIComponent(part)).join('/')
+    return baseUrl + '/' + pathParts.map(part => encodeURIComponent(part)).join('/')
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,5 +37,5 @@ export function waitFor(emitter, event) {
 }
 
 export const getEndpointUrl = (baseUrl, ...pathParts) => {
-    return baseUrl + '/' + pathParts.map(part => encodeURIComponent(part)).join('/')
+    return baseUrl + '/' + pathParts.map((part) => encodeURIComponent(part)).join('/')
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,3 +35,7 @@ export function waitFor(emitter, event) {
         emitter.once('error', onError)
     })
 }
+
+export const getEndpointUrl = (baseUrl, ...pathParts) => {
+	return baseUrl + '/' + pathParts.map(part => encodeURIComponent(part)).join('/')
+}

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -83,11 +83,11 @@ describe('utils', () => {
             const uid = uuid('test') // generate new text to ensure count starts at 1
             expect(uuid(uid) < uuid(uid)).toBeTruthy()
         })
-	})
+    })
 
-	describe('getEndpointUrl', () => {
-		const streamId = 'x/y'
-		const url = getEndpointUrl('http://example.com', 'abc', streamId, 'def')
-		expect(url.toLowerCase()).toBe('http://example.com/abc/x%2fy/def')
-	});
+    describe('getEndpointUrl', () => {
+        const streamId = 'x/y'
+        const url = getEndpointUrl('http://example.com', 'abc', streamId, 'def')
+        expect(url.toLowerCase()).toBe('http://example.com/abc/x%2fy/def')
+    })
 })

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon'
 import debugFactory from 'debug'
 
 import authFetch from '../../src/rest/authFetch'
-import { uuid } from '../../src/utils'
+import { uuid, getEndpointUrl } from '../../src/utils'
 
 const debug = debugFactory('StreamrClient::test::utils')
 const express = require('express')
@@ -83,5 +83,11 @@ describe('utils', () => {
             const uid = uuid('test') // generate new text to ensure count starts at 1
             expect(uuid(uid) < uuid(uid)).toBeTruthy()
         })
-    })
+	})
+
+	describe('getEndpointUrl', () => {
+		const streamId = 'x/y'
+		const url = getEndpointUrl('http://example.com', 'abc', streamId, 'def')
+		expect(url.toLowerCase()).toBe('http://example.com/abc/x%2fy/def')
+	});
 })


### PR DESCRIPTION
Added path parameter encoding to REST API urls. Stream-related endpoints need encoding to support custom IDs. 

DataUnion endpoints are encoded only partially (all suffixes are URL-safe, no need to refactor).