### PR TITLE
NET-65: Can create stream without "name" field

### DIFF
--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -68,10 +68,6 @@ export async function createStream(props) {
     this.debug('getStreamByName', {
         props,
     })
-    if (!props || !props.name) {
-        throw new Error('Stream properties must contain a "name" field!')
-    }
-
     const json = await authFetch(
         `${this.options.restUrl}/streams`,
         this.session,


### PR DESCRIPTION
Name field is optional in POST /stream endpoint, remove the assertion check.