### PR TITLE
Bug: getOrCreateStream for non-existing stream

### DIFF
--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -46,9 +46,8 @@ export async function getStream(streamId) {
     } catch (e) {
         if (e.response && e.response.status === 404) {
             return undefined
-        } else { // eslint-disable-line no-else-return
-            throw e
         }
+        throw e
     }
 }
 

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -40,8 +40,16 @@ export async function getStream(streamId) {
         streamId,
     })
     const url = getEndpointUrl(this.options.restUrl, 'streams', streamId)
-    const json = await authFetch(url, this.session)
-    return json ? new Stream(this, json) : undefined
+    try {
+        const json = await authFetch(url, this.session)
+        return new Stream(this, json)
+    } catch (e) {
+        if (e.response && e.response.status === 404) {
+            return undefined
+        } else { // eslint-disable-line no-else-return
+            throw e
+        }
+    }
 }
 
 export async function listStreams(query = {}) {
@@ -100,7 +108,7 @@ export async function getOrCreateStream(props) {
 
     // If still nothing, throw
     if (!json) {
-        throw new Error(`Unable to find or create stream: ${props.name}`)
+        throw new Error(`Unable to find or create stream: ${props.name || props.id}`)
     } else {
         return new Stream(this, json)
     }

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -47,6 +47,20 @@ describe('StreamEndpoints', () => {
         })
     })
 
+    describe('get', () => {
+        it('get an existing Stream', async () => {
+            const stream = await client.createStream()
+            const existingStream = await client.getStream(stream.id)
+            assert.strictEqual(existingStream.id, stream.id)
+        })
+
+        it('get a non-existing Stream', async () => {
+            const id = `${wallet.address}/StreamEndpoints-integration-nonexisting-${Date.now()}`
+            const stream = await client.getStream(id)
+            assert.strictEqual(stream, undefined)
+        })
+    })
+
     describe('getOrCreate', () => {
         it('getOrCreate an existing Stream', async () => {
             const stream = await client.createStream({
@@ -60,13 +74,22 @@ describe('StreamEndpoints', () => {
             assert.strictEqual(existingStream.name, stream.name)
         })
 
-        it('getOrCreate a new Stream', async () => {
+        it('getOrCreate a new Stream by name', async () => {
             const newName = `StreamEndpoints-integration-${Date.now()}`
             const newStream = await client.getOrCreateStream({
                 name: newName,
             })
 
             assert.strictEqual(newStream.name, newName)
+        })
+
+        it('getOrCreate a new Stream by id', async () => {
+            const newId = `${wallet.address}/StreamEndpoints-integration-${Date.now()}`
+            const newStream = await client.getOrCreateStream({
+                id: newId,
+            })
+
+            assert.strictEqual(newStream.id, newId)
         })
     })
 
@@ -196,9 +219,7 @@ describe('StreamEndpoints', () => {
     describe('Stream deletion', () => {
         it('Stream.delete', async () => {
             await createdStream.delete()
-            await assert.rejects(async () => {
-                await client.getStream(createdStream.id)
-            })
+            assert.strictEqual(await client.getStream(createdStream.id), undefined)
         })
     })
 })

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -47,7 +47,7 @@ describe('StreamEndpoints', () => {
         })
     })
 
-    describe('get', () => {
+    describe('getStream', () => {
         it('get an existing Stream', async () => {
             const stream = await client.createStream()
             const existingStream = await client.getStream(stream.id)


### PR DESCRIPTION
```getOrCreateStream``` doesn't create a stream if it is called with an ```id``` parameter.

```getOrCreateStream``` can be called with an ```id``` parameter or with a name parameter, and as the name suggests it either gets and existing stream or creates a new one. All three other use cases work ok:
- get stream by name
- create a new stream by name
- get stream by id

The problem is in ```getStream``` which throws an error as it gets HTTP 404 error from the backend. There is no documentation what ```getStream``` should return if the stream doesn't exists (```undefined``` or throw an error). Most likely it should return an ```undefined```, because:

- ```getStreamByName``` also returns undefined in the same situation
- ```getOrCreateStream``` tries to checks whether getStream returns an ```undefined```: https://github.com/streamr-dev/streamr-client-javascript/blob/693f3f3945ae355e5edd2fbf93cb42591653f1a7/src/rest/StreamEndpoints.js#L96
- there is a ternary operator in ```getStream``` which tries to return ```undefined:``` https://github.com/streamr-dev/streamr-client-javascript/blob/693f3f3945ae355e5edd2fbf93cb42591653f1a7/src/rest/StreamEndpoints.js#L44 (it doesn't do that, because ```authFetch``` throws the error)

This PR modifies the ```getStream``` method to return ```undefined``` for non-existing streams. ```getOrCreateStream``` doesn't need any modifications as it can already handle the ```undefined``` result from getStream().