### PR TITLE
Fix DU2 test

### DIFF
--- a/test/integration/DataUnionEndpoints.test.js
+++ b/test/integration/DataUnionEndpoints.test.js
@@ -5,10 +5,10 @@ import { wait } from 'streamr-test-utils'
 
 import StreamrClient from '../../src'
 import * as Token from '../../contracts/TestToken.json'
-
-import config from './config'
 import { getEndpointUrl } from '../../src/utils'
 import authFetch from '../../src/rest/authFetch'
+
+import config from './config'
 
 const log = debug('StreamrClient::DataUnionEndpoints::integration-test')
 
@@ -20,14 +20,14 @@ describe('DataUnionEndPoints', () => {
     let adminWallet
 
     const createProduct = async () => {
-        const DATA_UNION_VERSION = 2;
+        const DATA_UNION_VERSION = 2
         const properties = {
             beneficiaryAddress: dataUnion.address,
             type: 'DATAUNION',
             dataUnionVersion: DATA_UNION_VERSION
         }
         const url = getEndpointUrl(config.clientOptions.restUrl, 'products')
-        return await authFetch(
+        return authFetch(
             url,
             adminClient.session,
             {
@@ -67,7 +67,7 @@ describe('DataUnionEndPoints', () => {
         await dataUnion.isReady(2000, 200000)
         log(`DataUnion ${dataUnion.address} is ready to roll`)
         await adminClient.createSecret(dataUnion.address, 'secret', 'DataUnionEndpoints test secret')
-        await createProduct();
+        await createProduct()
     }, 300000)
 
     afterAll(async () => {

--- a/test/integration/DataUnionEndpoints.test.js
+++ b/test/integration/DataUnionEndpoints.test.js
@@ -20,7 +20,7 @@ describe('DataUnionEndPoints', () => {
     let adminWallet
 
     const createProduct = async () => {
-        const DATA_UNION_VERSION = 2
+        const DATA_UNION_VERSION = 1
         const properties = {
             beneficiaryAddress: dataUnion.address,
             type: 'DATAUNION',

--- a/test/integration/DataUnionEndpoints.test.js
+++ b/test/integration/DataUnionEndpoints.test.js
@@ -7,6 +7,8 @@ import StreamrClient from '../../src'
 import * as Token from '../../contracts/TestToken.json'
 
 import config from './config'
+import { getEndpointUrl } from '../../src/utils'
+import authFetch from '../../src/rest/authFetch'
 
 const log = debug('StreamrClient::DataUnionEndpoints::integration-test')
 
@@ -16,6 +18,24 @@ describe('DataUnionEndPoints', () => {
     let testProvider
     let adminClient
     let adminWallet
+
+    const createProduct = async () => {
+        const DATA_UNION_VERSION = 2;
+        const properties = {
+            beneficiaryAddress: dataUnion.address,
+            type: 'DATAUNION',
+            dataUnionVersion: DATA_UNION_VERSION
+        }
+        const url = getEndpointUrl(config.clientOptions.restUrl, 'products')
+        return await authFetch(
+            url,
+            adminClient.session,
+            {
+                method: 'POST',
+                body: JSON.stringify(properties)
+            }
+        )
+    }
 
     beforeAll(async () => {
         testProvider = new providers.JsonRpcProvider(config.ethereumServerUrl)
@@ -47,6 +67,7 @@ describe('DataUnionEndPoints', () => {
         await dataUnion.isReady(2000, 200000)
         log(`DataUnion ${dataUnion.address} is ready to roll`)
         await adminClient.createSecret(dataUnion.address, 'secret', 'DataUnionEndpoints test secret')
+        await createProduct();
     }, 300000)
 
     afterAll(async () => {


### PR DESCRIPTION
Create a product in backend so that E&E can analyze the DU version.

That change doesn't solve the problem. Maybe there is some conflict in environment config?

Stacktrace in E&E:
`java.lang.IndexOutOfBoundsException: Index: 0
	at java.util.Collections$EmptyList.get(Collections.java:4456)
	at com.streamr.client.dataunion.contracts.DataUnionSidechain$42.call(DataUnionSidechain.java:647)
	at com.streamr.client.dataunion.contracts.DataUnionSidechain$42.call(DataUnionSidechain.java:642)
	at org.web3j.protocol.core.RemoteCall.send(RemoteCall.java:42)
	at com.streamr.client.dataunion.DataUnion.isMemberActive(DataUnion.java:243)
	at com.unifina.service.DataUnionJoinRequestService.isMemberActive(DataUnionJoinRequestService.groovy:43)
	at com.unifina.service.DataUnionJoinRequestService.onApproveJoinRequest(DataUnionJoinRequestService.groovy:83)
	at com.unifina.service.DataUnionJoinRequestService.create(DataUnionJoinRequestService.groovy:188)
	at com.unifina.controller.DataUnionJoinRequestApiController.save(DataUnionJoinRequestApiController.groovy:38)
	at com.brandseye.cors.CorsFilter.doFilter(CorsFilter.java:100)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)`