### PR TITLE
Fix provider signing

### DIFF
--- a/src/MessageCreationUtil.js
+++ b/src/MessageCreationUtil.js
@@ -68,7 +68,7 @@ export default class MessageCreationUtil {
                 this.publisherId = ethers.utils.computeAddress(this.auth.privateKey).toLowerCase()
             } else if (this.auth.provider !== undefined) {
                 const provider = new ethers.providers.Web3Provider(this.auth.provider)
-                this.publisherId = provider.getSigner().address.toLowerCase()
+                this.publisherId = (await provider.getSigner().getAddress()).toLowerCase()
             } else if (this.auth.apiKey !== undefined) {
                 const hexString = ethers.utils.hexlify(Buffer.from(await this.getUsername(), 'utf8'))
                 this.publisherId = ethers.utils.sha256(hexString)

--- a/test/integration/StreamEndpoints.test.js
+++ b/test/integration/StreamEndpoints.test.js
@@ -117,13 +117,13 @@ describe('StreamEndpoints', () => {
     describe('getStreamPublishers', () => {
         it('retrieves a list of publishers', async () => {
             const publishers = await client.getStreamPublishers(createdStream.id)
-            assert.deepStrictEqual(publishers, [client.signer.address.toLowerCase()])
+            assert.deepStrictEqual(publishers, [(await client.signer.getAddress()).toLowerCase()])
         })
     })
 
     describe('isStreamPublisher', () => {
         it('returns true for valid publishers', async () => {
-            const valid = await client.isStreamPublisher(createdStream.id, client.signer.address.toLowerCase())
+            const valid = await client.isStreamPublisher(createdStream.id, (await client.signer.getAddress()).toLowerCase())
             assert(valid)
         })
         it('returns false for invalid publishers', async () => {
@@ -135,13 +135,13 @@ describe('StreamEndpoints', () => {
     describe('getStreamSubscribers', () => {
         it('retrieves a list of publishers', async () => {
             const subscribers = await client.getStreamSubscribers(createdStream.id)
-            assert.deepStrictEqual(subscribers, [client.signer.address.toLowerCase()])
+            assert.deepStrictEqual(subscribers, [(await client.signer.getAddress()).toLowerCase()])
         })
     })
 
     describe('isStreamSubscriber', () => {
         it('returns true for valid subscribers', async () => {
-            const valid = await client.isStreamSubscriber(createdStream.id, client.signer.address.toLowerCase())
+            const valid = await client.isStreamSubscriber(createdStream.id, (await client.signer.getAddress()).toLowerCase())
             assert(valid)
         })
         it('returns false for invalid subscribers', async () => {

--- a/test/integration/StreamrClient.test.js
+++ b/test/integration/StreamrClient.test.js
@@ -782,7 +782,7 @@ describe('StreamrClient', () => {
                     const subStream = client._getSubscribedStreamPartition(stream.id, 0) // eslint-disable-line no-underscore-dangle
                     const publishers = await subStream.getPublishers()
                     const map = {}
-                    map[client.signer.address.toLowerCase()] = true
+                    map[(await client.signer.getAddress()).toLowerCase()] = true
                     assert.deepStrictEqual(publishers, map)
                     assert.strictEqual(streamMessage.signatureType, StreamMessage.SIGNATURE_TYPES.ETH)
                     assert(streamMessage.getPublisherId())
@@ -824,7 +824,7 @@ describe('StreamrClient', () => {
                     const subStream = client._getSubscribedStreamPartition(stream.id, 0) // eslint-disable-line no-underscore-dangle
                     const publishers = await subStream.getPublishers()
                     const map = {}
-                    map[client.signer.address.toLowerCase()] = true
+                    map[(await client.signer.getAddress()).toLowerCase()] = true
                     assert.deepStrictEqual(publishers, map)
                     assert.strictEqual(streamMessage.signatureType, StreamMessage.SIGNATURE_TYPES.ETH)
                     assert(streamMessage.getPublisherId())

--- a/test/unit/Signer.test.js
+++ b/test/unit/Signer.test.js
@@ -80,7 +80,7 @@ describe('Signer', () => {
 
         it('should sign StreamMessageV31 with null previous ref correctly', async () => {
             const streamMessage = new StreamMessage({
-                messageId: new MessageID(streamId, 0, timestamp, 0, signer.address, 'chain-id'),
+                messageId: new MessageID(streamId, 0, timestamp, 0, await signer.getAddress(), 'chain-id'),
                 prevMsgRef: null,
                 content: data,
                 encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
@@ -88,20 +88,20 @@ describe('Signer', () => {
                 signature: null
             })
             const payload = streamMessage.getStreamId() + streamMessage.getStreamPartition() + streamMessage.getTimestamp()
-                + streamMessage.messageId.sequenceNumber + signer.address.toLowerCase() + streamMessage.messageId.msgChainId
+                + streamMessage.messageId.sequenceNumber + (await signer.getAddress()).toLowerCase() + streamMessage.messageId.msgChainId
                 + streamMessage.getSerializedContent()
 
             const expectedSignature = await signer.signData(payload)
             await signer.signStreamMessage(streamMessage)
             expect(streamMessage.signature).toBe(expectedSignature)
-            expect(streamMessage.getPublisherId()).toBe(signer.address)
+            expect(streamMessage.getPublisherId()).toBe(await signer.getAddress())
             expect(streamMessage.signatureType).toBe(StreamMessage.SIGNATURE_TYPES.ETH)
         })
 
         it('should sign StreamMessageV31 with non-null previous ref correctly', async () => {
             const streamMessage = new StreamMessage({
                 version: 31,
-                messageId: new MessageID(streamId, 0, timestamp, 0, signer.address, 'chain-id'),
+                messageId: new MessageID(streamId, 0, timestamp, 0, await signer.getAddress(), 'chain-id'),
                 prevMsgRef: new MessageRef(timestamp - 10, 0),
                 content: data,
                 encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
@@ -110,7 +110,7 @@ describe('Signer', () => {
             })
             const payload = [
                 streamMessage.getStreamId(), streamMessage.getStreamPartition(), streamMessage.getTimestamp(),
-                streamMessage.messageId.sequenceNumber, signer.address.toLowerCase(), streamMessage.messageId.msgChainId,
+                streamMessage.messageId.sequenceNumber, (await signer.getAddress()).toLowerCase(), streamMessage.messageId.msgChainId,
                 streamMessage.prevMsgRef.timestamp, streamMessage.prevMsgRef.sequenceNumber, streamMessage.getSerializedContent()
             ]
             const expectedSignature = await signer.signData(payload.join(''))
@@ -118,7 +118,7 @@ describe('Signer', () => {
             expect(expectedSignature).toEqual(await signer.signData(streamMessage.getPayloadToSign()))
             await signer.signStreamMessage(streamMessage)
             expect(streamMessage.signature).toBe(expectedSignature)
-            expect(streamMessage.getPublisherId()).toBe(signer.address)
+            expect(streamMessage.getPublisherId()).toBe(await signer.getAddress())
             expect(streamMessage.signatureType).toBe(StreamMessage.SIGNATURE_TYPES.ETH)
         })
     })

--- a/test/unit/SubscribedStreamPartition.test.js
+++ b/test/unit/SubscribedStreamPartition.test.js
@@ -147,7 +147,7 @@ describe('SubscribedStreamPartition', () => {
                 }
                 const timestamp = Date.now()
                 const msg = new StreamMessage({
-                    messageId: new MessageIDStrict(streamId, 0, timestamp, 0, signer.address, ''),
+                    messageId: new MessageIDStrict(streamId, 0, timestamp, 0, await signer.getAddress(), ''),
                     prevMesssageRef: null,
                     content: data,
                     messageType: StreamMessage.MESSAGE_TYPES.MESSAGE,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,9 +38,12 @@ const commonConfig = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['@babel/preset-env']
+                        configFile: path.resolve(__dirname, '.babelrc'),
+                        babelrc: false,
+                        cacheDirectory: true,
                     }
                 }
+
             },
             {
                 test: /(\.jsx|\.js)$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ const libraryName = pkg.name
 const commonConfig = {
     mode: isProduction ? 'production' : 'development',
     entry: path.join(__dirname, 'src', 'index.js'),
-    devtool: isProduction ? 'nosources-source-map' : 'source-map',
+    devtool: 'source-map',
     output: {
         path: path.join(__dirname, 'dist'),
         library: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ const commonConfig = {
 }
 
 const serverConfig = merge({}, commonConfig, {
+    name: 'node-lib',
     target: 'node',
     externals: [nodeExternals()],
     output: {
@@ -73,6 +74,7 @@ const serverConfig = merge({}, commonConfig, {
 })
 
 const clientConfig = merge({}, commonConfig, {
+    name: 'browser-lib',
     target: 'web',
     output: {
         libraryTarget: 'umd2',


### PR DESCRIPTION
When using a provider, getting the address is now an async operation. API changed somewhere, probably between ethers 4.x and 5.x but because the provider code path doesn't get covered, this bug slipped through.

Also backported:
* fix to load babel preset config correctly (was ignoring preset-env config)
* change to always generate source map (hard to debug without this, no good reason to not just always have source available)
* gave names to webpack builds

Closes NET-167

