### PR TITLE
Drop apikey support

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -68,7 +68,7 @@ export default class Session extends EventEmitter {
                 this.options.unauthenticated = true
             }
             this.loginFunction = async () => {
-                throw new Error('Need either "privateKey", "ethereum", "apiKey", "username"+"password" or "sessionToken" to login.')
+                throw new Error('Need either "privateKey", "ethereum" or "sessionToken" to login.')
             }
         }
     }

--- a/src/rest/LoginEndpoints.ts
+++ b/src/rest/LoginEndpoints.ts
@@ -77,38 +77,17 @@ export class LoginEndpoints {
     }
 
     /** @internal */
-    async loginWithApiKey(apiKey: string) {
-        this.client.debug('loginWithApiKey %o', {
-            apiKey,
-        })
-        const url = getEndpointUrl(this.client.options.restUrl, 'login', 'apikey')
-        const props = {
-            apiKey,
-        }
-        return getSessionToken(url, props)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
+    async loginWithApiKey(_apiKey: string): Promise<any> {
+        const message = 'apiKey auth is no longer supported. Please create an ethereum identity.'
+        throw new AuthFetchError(message)
     }
 
     /** @internal */
-    async loginWithUsernamePassword(username: string, password: string) {
-        this.client.debug('loginWithUsernamePassword %o', {
-            username,
-        })
-        const url = getEndpointUrl(this.client.options.restUrl, 'login', 'password')
-        const props = {
-            username,
-            password,
-        }
-        try {
-            return await getSessionToken(url, props)
-        } catch (err) {
-            if (err && err.response && err.response.status === 404) {
-                // this 404s if running against new backend with username/password support removed
-                // wrap with appropriate error message
-                const message = 'username/password auth is no longer supported. Please create an ethereum identity.'
-                throw new AuthFetchError(message, err.response, err.body)
-            }
-            throw err
-        }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
+    async loginWithUsernamePassword(_username: string, _password: string): Promise<any> {
+        const message = 'username/password auth is no longer supported. Please create an ethereum identity.'
+        throw new AuthFetchError(message)
     }
 
     async getUserInfo() {

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -13,6 +13,7 @@ async function getUsername(client: StreamrClient) {
     return (
         username
         // edge case: if auth.apiKey is an anonymous key, userInfo.id is that anonymous key
+        // update: not sure if still needed now that apiKey auth has been disabled
         || id
     )
 }
@@ -48,5 +49,5 @@ export async function getUserId(client: StreamrClient) {
         return sha256(hexString)
     }
 
-    throw new Error('Need either "privateKey", "ethereum", "apiKey", "username"+"password" or "sessionToken" to derive the publisher Id.')
+    throw new Error('Need either "privateKey", "ethereum" or "sessionToken" to derive the publisher Id.')
 }

--- a/test/integration/LoginEndpoints.test.ts
+++ b/test/integration/LoginEndpoints.test.ts
@@ -83,7 +83,6 @@ describe('LoginEndpoints', () => {
             const sessionToken = await client.loginWithApiKey('tester1-api-key')
             assert(sessionToken)
             assert(sessionToken.token)
-            // @ts-expect-error
             assert(sessionToken.expires)
         })
     })

--- a/test/integration/Session.test.ts
+++ b/test/integration/Session.test.ts
@@ -12,24 +12,13 @@ describe('Session', () => {
     })
 
     describe('Token retrievals', () => {
-        it('gets the token using api key', async () => {
+        it('fails if trying to use apiKey', async () => {
             expect.assertions(1)
-            await expect(createClient({
+            await expect(() => createClient({
                 auth: {
                     apiKey: 'tester1-api-key',
                 },
-            }).session.getSessionToken()).resolves.toBeTruthy()
-        })
-
-        it('fails when the used api key is invalid', async () => {
-            expect.assertions(1)
-            await expect(createClient({
-                auth: {
-                    apiKey: 'wrong-api-key',
-                },
-            }).session.getSessionToken()).rejects.toMatchObject({
-                body: expect.stringMatching(/invalid api key/i),
-            })
+            }).session.getSessionToken()).rejects.toThrow('no longer supported')
         })
 
         it('gets the token using private key', async () => {

--- a/test/unit/Session.test.ts
+++ b/test/unit/Session.test.ts
@@ -64,7 +64,7 @@ describe('Session', () => {
             await expect(async () => (
                 clientSessionToken.session.loginFunction()
             )).rejects.toThrow(
-                'Need either "privateKey", "ethereum", "apiKey", "username"+"password" or "sessionToken" to login.'
+                'Need either "privateKey", "ethereum" or "sessionToken" to login.'
             )
         })
 
@@ -74,8 +74,8 @@ describe('Session', () => {
             })
             clientNone.onError = () => {}
             await clientNone.session.loginFunction().catch((err) => {
-                expect(err.toString()).toEqual(
-                    'Error: Need either "privateKey", "ethereum", "apiKey", "username"+"password" or "sessionToken" to login.'
+                expect(err.message).toEqual(
+                    'Need either "privateKey", "ethereum" or "sessionToken" to login.'
                 )
             })
             clientNone.onError = () => {}
@@ -83,7 +83,7 @@ describe('Session', () => {
             await expect(async () => (
                 clientSessionToken.session.loginFunction()
             )).rejects.toThrow(
-                'Need either "privateKey", "ethereum", "apiKey", "username"+"password" or "sessionToken" to login.'
+                'Need either "privateKey", "ethereum" or "sessionToken" to login.'
             )
         })
     })
@@ -134,7 +134,7 @@ describe('Session', () => {
             beforeEach(() => {
                 session = new Session(undefined as any)
                 session.options.unauthenticated = false
-                msg = 'Error: Need either "privateKey", "ethereum", "apiKey" or "username"+"password" to login.'
+                msg = 'Need either "privateKey", "ethereum" or "sessionToken" to login.'
                 session.loginFunction = sinon.stub().rejects(new Error(msg))
                 clientSessionToken.onError = () => {}
             })


### PR DESCRIPTION
Like the username/password deprecation, this keeps support in the client going until `/login/apikey` 404s.

Tests currently fail because unlike `/login/password`, `/login/apikey` seems to continue to exist in the docker e&e, despite https://github.com/streamr-dev/engine-and-editor/pull/866 landing. Perhaps @kare or @teogeb know why/how.

