### PR TITLE
Upgrade MetaMask support

### DIFF
--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -742,7 +742,7 @@
         "qs": "^6.9.4",
         "randomstring": "^1.1.5",
         "receptacle": "^1.3.2",
-        "streamr-client-protocol": "^5.0.0-beta.9",
+        "streamr-client-protocol": "^5.0.0-beta.10",
         "uuid": "^8.2.0",
         "webpack-node-externals": "^1.7.2",
         "ws": "^7.3.0"

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -5035,7 +5035,7 @@
         "qs": "^6.9.4",
         "randomstring": "^1.1.5",
         "receptacle": "^1.3.2",
-        "streamr-client-protocol": "^5.0.0-beta.9",
+        "streamr-client-protocol": "^5.0.0-beta.10",
         "uuid": "^8.2.0",
         "webpack-node-externals": "^1.7.2",
         "ws": "^7.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client",
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client",
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "description": "JavaScript client library for Streamr",
   "repository": {
     "type": "git",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -109,7 +109,7 @@ export default function ClientConfig(opts: StreamrClientOptions = {}) {
 
     const options: StrictStreamrClientOptions = {
         ...defaults,
-        ...opts,
+        ...opts, // sidechain is not merged with the defaults
         dataUnion: {
             ...defaults.dataUnion,
             ...opts.dataUnion

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -33,7 +33,7 @@ export type StrictStreamrClientOptions = {
     groupKeys: Todo
     keyExchange: Todo
     mainnet?: ConnectionInfo|string
-    sidechain?: ConnectionInfo|string
+    sidechain: ConnectionInfo & { chainId?: number } // TODO should the chainId be a required parameter?
     tokenAddress: EthereumAddress,
     dataUnion: {
         minimumWithdrawTokenWei: BigNumber|number|string
@@ -86,7 +86,10 @@ export default function ClientConfig(opts: StreamrClientOptions = {}) {
         // Ethereum and Data Union related options
         // For ethers.js provider params, see https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#provider
         mainnet: undefined, // Default to ethers.js default provider settings
-        sidechain: 'https://rpc.xdaichain.com/',
+        sidechain: {
+            url: 'https://rpc.xdaichain.com/',
+            chainId: 100
+        },
         tokenAddress: '0x0Cf0Ee63788A0849fE5297F3407f701E122cC023',
         dataUnion: {
             minimumWithdrawTokenWei: '1000000', // Threshold value set in AMB configs, smallest token amount to pass over the bridge

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -33,7 +33,7 @@ export type StrictStreamrClientOptions = {
     groupKeys: Todo
     keyExchange: Todo
     mainnet?: ConnectionInfo|string
-    sidechain: ConnectionInfo & { chainId?: number } // TODO should the chainId be a required parameter?
+    sidechain: ConnectionInfo & { chainId?: number }
     tokenAddress: EthereumAddress,
     dataUnion: {
         minimumWithdrawTokenWei: BigNumber|number|string

--- a/src/Ethereum.js
+++ b/src/Ethereum.js
@@ -24,12 +24,13 @@ export default class StreamrEthereum {
             this.getSidechainSigner = async () => new Wallet(key, this.getSidechainProvider())
         } else if (auth.ethereum) {
             this._getAddress = async () => {
-                return auth.ethereum
-                    .request({ method: 'eth_requestAccounts' })
-                    .then((accounts) => getAddress(accounts[0])) // convert to checksum case
-                    .catch(() => {
-                        throw new Error('no addresses connected+selected in Metamask')
-                    })
+                try {
+                    const accounts = await auth.ethereum.request({ method: 'eth_requestAccounts' })
+                    const account = getAddress(accounts[0]) // convert to checksum case
+                    return account
+                } catch {
+                    throw new Error('no addresses connected+selected in Metamask')
+                }
             }
             this._getSigner = () => {
                 const metamaskProvider = new Web3Provider(auth.ethereum)

--- a/src/Ethereum.js
+++ b/src/Ethereum.js
@@ -37,7 +37,6 @@ export default class StreamrEthereum {
                 return metamaskSigner
             }
             this._getSidechainSigner = async () => {
-                // chainId is required for checking when using Metamask
                 if (!options.sidechain || !options.sidechain.chainId) {
                     throw new Error('Streamr sidechain not configured (with chainId) in the StreamrClient options!')
                 }
@@ -45,7 +44,7 @@ export default class StreamrEthereum {
                 const metamaskProvider = new Web3Provider(auth.ethereum)
                 const { chainId } = await metamaskProvider.getNetwork()
                 if (chainId !== options.sidechain.chainId) {
-                    throw new Error(`Please connect Metamask to Ethereum blockchain with chainId ${options.sidechain.chainId}`)
+                    throw new Error(`Please connect Metamask to Ethereum blockchain with chainId ${options.sidechain.chainId}: current chainId is ${chainId}`)
                 }
                 const metamaskSigner = metamaskProvider.getSigner()
                 return metamaskSigner

--- a/src/Ethereum.js
+++ b/src/Ethereum.js
@@ -45,7 +45,9 @@ export default class StreamrEthereum {
                 const metamaskProvider = new Web3Provider(auth.ethereum)
                 const { chainId } = await metamaskProvider.getNetwork()
                 if (chainId !== options.sidechain.chainId) {
-                    throw new Error(`Please connect Metamask to Ethereum blockchain with chainId ${options.sidechain.chainId}: current chainId is ${chainId}`)
+                    throw new Error(
+                        `Please connect Metamask to Ethereum blockchain with chainId ${options.sidechain.chainId}: current chainId is ${chainId}`
+                    )
                 }
                 const metamaskSigner = metamaskProvider.getSigner()
                 return metamaskSigner

--- a/src/StreamrClient.ts
+++ b/src/StreamrClient.ts
@@ -367,7 +367,7 @@ export class StreamrClient extends EventEmitter {
         return this.connection.enableAutoDisconnect(...args)
     }
 
-    getAddress() {
+    async getAddress(): Promise<EthereumAddress> {
         return this.ethereum.getAddress()
     }
 

--- a/src/dataunion/DataUnion.ts
+++ b/src/dataunion/DataUnion.ts
@@ -93,7 +93,7 @@ export class DataUnion {
      * Send a joinRequest, or get into data union instantly with a data union secret
      */
     async join(secret?: string): Promise<JoinResponse> {
-        const memberAddress = this.client.getAddress() as string
+        const memberAddress = await this.client.getAddress()
         const body: any = {
             memberAddress
         }
@@ -131,7 +131,7 @@ export class DataUnion {
      * @returns receipt once withdraw is complete (tokens are seen in mainnet)
      */
     async withdrawAll(options?: DataUnionWithdrawOptions): Promise<TransactionReceipt> {
-        const recipientAddress = this.client.getAddress()
+        const recipientAddress = await this.client.getAddress()
         return this._executeWithdraw(
             () => this.getWithdrawAllTx(),
             recipientAddress,
@@ -462,7 +462,7 @@ export class DataUnion {
      * @return that resolves when the new DU is deployed over the bridge to side-chain
      */
     static async _deploy(options: DataUnionDeployOptions = {}, client: StreamrClient): Promise<DataUnion> {
-        const deployerAddress = client.getAddress()
+        const deployerAddress = await client.getAddress()
         const {
             owner,
             joinPartAgents,

--- a/test/integration/dataunion/adminFee.test.ts
+++ b/test/integration/dataunion/adminFee.test.ts
@@ -41,7 +41,7 @@ describe('DataUnion admin fee', () => {
         const dataUnion = await adminClient.deployDataUnion()
         const oldFee = await dataUnion.getAdminFee()
         log(`DU owner: ${await dataUnion.getAdminAddress()}`)
-        log(`Sending tx from ${adminClient.getAddress()}`)
+        log(`Sending tx from ${await adminClient.getAddress()}`)
         const tr = await dataUnion.setAdminFee(0.1)
         log(`Transaction receipt: ${JSON.stringify(tr)}`)
         const newFee = await dataUnion.getAdminFee()

--- a/test/integration/dataunion/deploy.test.ts
+++ b/test/integration/dataunion/deploy.test.ts
@@ -34,7 +34,7 @@ describe('DataUnion deploy', () => {
 
         it('not specified: defaults to deployer', async () => {
             const dataUnion = await adminClient.deployDataUnion()
-            expect(await dataUnion.getAdminAddress()).toBe(adminClient.getAddress())
+            expect(await dataUnion.getAdminAddress()).toBe(await adminClient.getAddress())
         }, 60000)
 
         it('specified', async () => {

--- a/test/unit/Config.test.ts
+++ b/test/unit/Config.test.ts
@@ -11,13 +11,13 @@ const createClient = (privateKey: BytesLike) => {
 
 describe('Config', () => {
     describe('private key', () => {
-        it('string', () => {
+        it('string', async () => {
             const client = createClient('0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF')
-            expect(client.getAddress()).toBe('0xFCAd0B19bB29D4674531d6f115237E16AfCE377c')
+            expect(await client.getAddress()).toBe('0xFCAd0B19bB29D4674531d6f115237E16AfCE377c')
         })
-        it('byteslike', () => {
+        it('byteslike', async () => {
             const client = createClient(arrayify('0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'))
-            expect(client.getAddress()).toBe('0xFCAd0B19bB29D4674531d6f115237E16AfCE377c')
+            expect(await client.getAddress()).toBe('0xFCAd0B19bB29D4674531d6f115237E16AfCE377c')
         })
     })
 })


### PR DESCRIPTION
Fetch the account address from MetaMask using `request({ method: 'eth_requestAccounts' })`. Previously used the deprecated `selectedAddress` field.

Configure `chainId` to StreamrClient options. The parameter is required when using MetaMask sidechain signing.

**BREAKING CHANGE:** `client.getAddress()` is now async

We could be more explicit about network chainIds. Sidechain chainId could be a required parameter in StreamrClient `options` and we could also add chainId parameter to `options.mainnet` definition. The chainId validation can be enhanced in another PR later, if needed.

Note that there are currently no automated tests to check the MetaMask integration.