### PR TITLE
Public type definitions

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -13,6 +13,16 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 // @ts-expect-error
 Debug.formatters.n = (v) => Debug.humanize(v)
 
+export interface ConnectionOptions {
+    url?: string,
+    autoConnect?: boolean
+    autoDisconnect?: boolean
+    disconnectDelay?: number
+    maxRetries?: number
+    retryBackoffFactor?: number
+    maxRetryWait?: number
+}
+
 export class ConnectionError extends Error {
     reason?: Todo
 
@@ -120,7 +130,7 @@ const STATE = {
 }
 
 /* eslint-disable no-underscore-dangle, no-param-reassign */
-function SocketConnector(connection: Todo) {
+function SocketConnector(connection: Connection) {
     let next: Todo
     let socket: Todo
     let startedConnecting = false
@@ -189,7 +199,7 @@ function SocketConnector(connection: Todo) {
         // connect
         async () => {
             startedConnecting = true
-            socket = await OpenWebSocket(connection.options.url, {
+            socket = await OpenWebSocket(connection.options.url!, {
                 perMessageDeflate: false,
                 debug: connection._debug,
             })
@@ -287,7 +297,7 @@ const DEFAULT_MAX_RETRIES = 10
 export default class Connection extends EventEmitter {
 
     _debug: Todo
-    options: Todo
+    options: ConnectionOptions
     retryCount: Todo
     wantsState: Todo
     connectionHandles: Todo
@@ -312,7 +322,7 @@ export default class Connection extends EventEmitter {
         }))
     }
 
-    constructor(options = {}, debug?: Debug.Debugger) {
+    constructor(options: ConnectionOptions = {}, debug?: Debug.Debugger) {
         super()
         this._debug = debug !== undefined
             ? debug.extend(counterId(this.constructor.name))

--- a/src/StreamrClient.ts
+++ b/src/StreamrClient.ts
@@ -23,13 +23,15 @@ import { StreamPartDefinition } from './stream'
 // TODO get metadata type from streamr-protocol-js project (it doesn't export the type definitions yet)
 export type OnMessageCallback = MaybeAsync<(message: any, metadata: any) => void>
 
-// TODO check if these are correct
-export interface SubscribeOptions {
-    resend?: boolean
+export type ResendOptions = {
     from?: { timestamp: number, sequenceNumber?: number }
     to?: { timestamp: number, sequenceNumber?: number }
     last?: number
 }
+
+export type SubscribeOptions = {
+    resend?: ResendOptions
+} & ResendOptions
 
 interface MessageEvent {
     data: any

--- a/src/StreamrClient.ts
+++ b/src/StreamrClient.ts
@@ -374,12 +374,12 @@ export class StreamrClient extends EventEmitter {
         return task
     }
 
-    enableAutoConnect(...args: Todo) {
-        return this.connection.enableAutoConnect(...args)
+    enableAutoConnect(autoConnect?: boolean) {
+        return this.connection.enableAutoConnect(autoConnect)
     }
 
-    enableAutoDisconnect(...args: Todo) {
-        return this.connection.enableAutoDisconnect(...args)
+    enableAutoDisconnect(autoDisconnect?: boolean) {
+        return this.connection.enableAutoDisconnect(autoDisconnect)
     }
 
     getAddress(): EthereumAddress {

--- a/src/StreamrClient.ts
+++ b/src/StreamrClient.ts
@@ -7,7 +7,7 @@ import { validateOptions } from './stream/utils'
 import Config, { StreamrClientOptions, StrictStreamrClientOptions } from './Config'
 import StreamrEthereum from './Ethereum'
 import Session from './Session'
-import Connection, { ConnectionError } from './Connection'
+import Connection, { ConnectionError, ConnectionOptions } from './Connection'
 import Publisher from './publish'
 import { Subscriber, Subscription } from './subscribe'
 import { getUserId } from './user'
@@ -29,10 +29,9 @@ interface MessageEvent {
 /**
  * Wrap connection message events with message parsing.
  */
-
 class StreamrConnection extends Connection {
     // TODO define args type when we convert Connection class to TypeScript
-    constructor(options: Todo, debug?: Debug.Debugger) {
+    constructor(options: ConnectionOptions, debug?: Debug.Debugger) {
         super(options, debug)
         this.on('message', this.onConnectionMessage)
     }
@@ -160,6 +159,7 @@ export class StreamrClient extends EventEmitter {
     /** @internal */
     ethereum: StreamrEthereum
 
+    // TODO annotate connection parameter as internal parameter if possible?
     constructor(options: StreamrClientOptions = {}, connection?: StreamrConnection) {
         super()
         this.id = counterId(`${this.constructor.name}:${uid}`)

--- a/src/StreamrClient.ts
+++ b/src/StreamrClient.ts
@@ -18,6 +18,7 @@ import { DataUnion, DataUnionDeployOptions } from './dataunion/DataUnion'
 import { BigNumber } from '@ethersproject/bignumber'
 import { getAddress } from '@ethersproject/address'
 import { Contract } from '@ethersproject/contracts'
+import { StreamPartDefinition } from './stream'
 
 // TODO get metadata type from streamr-protocol-js project (it doesn't export the type definitions yet)
 export type OnMessageCallback = MaybeAsync<(message: any, metadata: any) => void>
@@ -280,13 +281,13 @@ export class StreamrClient extends EventEmitter {
         ])
     }
 
-    getSubscriptions(...args: Todo) {
-        return this.subscriber.getAll(...args)
+    getSubscriptions(): Subscription[] {
+        return this.subscriber.getAll()
     }
 
-    getSubscription(...args: Todo) {
+    getSubscription(definition: StreamPartDefinition) {
         // @ts-expect-error
-        return this.subscriber.get(...args)
+        return this.subscriber.get(definition)
     }
 
     async ensureConnected() {

--- a/src/rest/StreamEndpoints.ts
+++ b/src/rest/StreamEndpoints.ts
@@ -226,6 +226,7 @@ export class StreamEndpoints {
     }
 
     async getStreamLast(streamObjectOrId: Stream|string): Promise<StreamMessageAsObject> {
+        // @ts-expect-error
         const { streamId, streamPartition = 0, count = 1 } = validateOptions(streamObjectOrId)
         this.client.debug('getStreamLast %o', {
             streamId,
@@ -234,6 +235,7 @@ export class StreamEndpoints {
         })
 
         const url = (
+            // @ts-expect-error
             getEndpointUrl(this.client.options.restUrl, 'streams', streamId, 'data', 'partitions', streamPartition, 'last')
             + `?${qs.stringify({ count })}`
         )

--- a/src/rest/StreamEndpoints.ts
+++ b/src/rest/StreamEndpoints.ts
@@ -11,7 +11,7 @@ import StreamPart from '../stream/StreamPart'
 import { isKeyExchangeStream } from '../stream/KeyExchange'
 
 import authFetch, { ErrorCode, NotFoundError } from './authFetch'
-import { EthereumAddress, Todo } from '../types'
+import { EthereumAddress } from '../types'
 import { StreamrClient } from '../StreamrClient'
 // TODO change this import when streamr-client-protocol exports StreamMessage type or the enums types directly
 import { ContentType, EncryptionType, SignatureType, StreamMessageType } from 'streamr-client-protocol/dist/src/protocol/message_layer/StreamMessage'
@@ -254,7 +254,7 @@ export class StreamEndpoints {
         return result
     }
 
-    async publishHttp(streamObjectOrId: Stream|string, data: Todo, requestOptions: Todo = {}, keepAlive: boolean = true) {
+    async publishHttp(streamObjectOrId: Stream|string, data: any, requestOptions: any = {}, keepAlive: boolean = true) {
         let streamId
         if (streamObjectOrId instanceof Stream) {
             streamId = streamObjectOrId.id

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -3,7 +3,6 @@ import authFetch from '../rest/authFetch'
 
 import StorageNode from './StorageNode'
 import { StreamrClient } from '../StreamrClient'
-import { Todo } from '../types'
 
 // TODO explicit types: e.g. we never provide both streamId and id, or both streamPartition and partition
 export type StreamPartDefinition = string | { streamId?: string, streamPartition?: number, id?: string, partition?: number, stream?: Stream }
@@ -252,7 +251,7 @@ export class Stream {
         return json.map((item: any) => new StorageNode(item.storageNodeAddress))
     }
 
-    async publish(...theArgs: Todo) {
-        return this._client.publish(this.id, ...theArgs)
+    async publish(content: object, timestamp?: number|string|Date, partitionKey?: string) {
+        return this._client.publish(this.id, content, timestamp, partitionKey)
     }
 }

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -5,6 +5,11 @@ import StorageNode from './StorageNode'
 import { StreamrClient } from '../StreamrClient'
 import { Todo } from '../types'
 
+// TODO explicit types: e.g. we never provide both streamId and id, or both streamPartition and partition
+export type StreamPartDefinition = string | { streamId?: string, streamPartition?: number, id?: string, partition?: number, stream?: Stream }
+
+export type ValidatedStreamPartDefinition = { streamId: string, streamPartition: number, key: string}
+
 interface StreamPermisionBase {
     id: number
     operation: StreamOperation

--- a/src/stream/utils.ts
+++ b/src/stream/utils.ts
@@ -45,7 +45,7 @@ export function validateOptions(optionsOrStreamId: StreamPartDefinition): Valida
             options.streamId = optionsOrStreamId.id
         }
 
-        if (optionsOrStreamId.partition == null && optionsOrStreamId.streamPartition == null) {
+        if (optionsOrStreamId.partition != null && optionsOrStreamId.streamPartition == null) {
             options.streamPartition = optionsOrStreamId.partition
         }
 

--- a/src/stream/utils.ts
+++ b/src/stream/utils.ts
@@ -7,8 +7,10 @@ import { inspect } from 'util'
 import { ControlLayer } from 'streamr-client-protocol'
 
 import { pTimeout } from '../utils'
+import { Todo } from '../types'
+import { StreamrClient } from '../StreamrClient'
 
-export function StreamKey({ streamId, streamPartition = 0 }) {
+export function StreamKey({ streamId, streamPartition = 0 }: Todo) {
     if (streamId == null) { throw new Error(`StreamKey: invalid streamId (${typeof streamId}): ${streamId}`) }
 
     if (!Number.isInteger(streamPartition) || streamPartition < 0) {
@@ -17,13 +19,13 @@ export function StreamKey({ streamId, streamPartition = 0 }) {
     return `${streamId}::${streamPartition}`
 }
 
-export function validateOptions(optionsOrStreamId) {
+export function validateOptions(optionsOrStreamId: Todo): Todo {
     if (!optionsOrStreamId) {
         throw new Error('streamId is required!')
     }
 
     // Backwards compatibility for giving a streamId as first argument
-    let options = {}
+    let options: Todo = {}
     if (typeof optionsOrStreamId === 'string') {
         options = {
             streamId: optionsOrStreamId,
@@ -89,7 +91,7 @@ export async function waitForMatchingMessage({
     rejectOnTimeout = true,
     timeoutMessage,
     cancelTask,
-}) {
+}: Todo) {
     if (typeof matchFn !== 'function') {
         throw new Error(`matchFn required, got: (${typeof matchFn}) ${matchFn}`)
     }
@@ -98,7 +100,7 @@ export async function waitForMatchingMessage({
     let cleanup = () => {}
 
     const matchTask = new Promise((resolve, reject) => {
-        const tryMatch = (...args) => {
+        const tryMatch = (...args: Todo[]) => {
             try {
                 return matchFn(...args)
             } catch (err) {
@@ -107,19 +109,20 @@ export async function waitForMatchingMessage({
                 return false
             }
         }
-        let onDisconnected
-        const onResponse = (res) => {
+        let onDisconnected: Todo
+        const onResponse = (res: Todo) => {
             if (!tryMatch(res)) { return }
             // clean up err handler
             cleanup()
             resolve(res)
         }
 
-        const onErrorResponse = (res) => {
+        const onErrorResponse = (res: Todo) => {
             if (!tryMatch(res)) { return }
             // clean up success handler
             cleanup()
             const error = new Error(res.errorMessage)
+            // @ts-expect-error
             error.code = res.errorCode
             reject(error)
         }
@@ -128,12 +131,12 @@ export async function waitForMatchingMessage({
             if (cancelTask) { cancelTask.catch(() => {}) } // ignore
             connection.off('disconnected', onDisconnected)
             connection.off(ControlMessage.TYPES.ErrorResponse, onErrorResponse)
-            types.forEach((type) => {
+            types.forEach((type: Todo) => {
                 connection.off(type, onResponse)
             })
         }
 
-        types.forEach((type) => {
+        types.forEach((type: Todo) => {
             connection.on(type, onResponse)
         })
 
@@ -141,6 +144,7 @@ export async function waitForMatchingMessage({
 
         onDisconnected = () => {
             cleanup()
+            // @ts-expect-error
             resolve() // noop
         }
 
@@ -171,7 +175,7 @@ export async function waitForMatchingMessage({
  * Wait for matching response types to requestId, or ErrorResponse.
  */
 
-export async function waitForResponse({ requestId, timeoutMessage = `Waiting for response to: ${requestId}.`, ...opts }) {
+export async function waitForResponse({ requestId, timeoutMessage = `Waiting for response to: ${requestId}.`, ...opts }: Todo) {
     if (requestId == null) {
         throw new Error(`requestId required, got: (${typeof requestId}) ${requestId}`)
     }
@@ -180,13 +184,13 @@ export async function waitForResponse({ requestId, timeoutMessage = `Waiting for
         ...opts,
         requestId,
         timeoutMessage,
-        matchFn(res) {
+        matchFn(res: Todo) {
             return res.requestId === requestId
         }
     })
 }
 
-export async function waitForRequestResponse(client, request, opts = {}) {
+export async function waitForRequestResponse(client: StreamrClient, request: Todo, opts: Todo = {}) {
     return waitForResponse({
         connection: client.connection,
         types: PAIRS.get(request.type),

--- a/src/stream/utils.ts
+++ b/src/stream/utils.ts
@@ -9,6 +9,7 @@ import { ControlLayer } from 'streamr-client-protocol'
 import { pTimeout } from '../utils'
 import { Todo } from '../types'
 import { StreamrClient } from '../StreamrClient'
+import { StreamPartDefinition, ValidatedStreamPartDefinition } from '.'
 
 export function StreamKey({ streamId, streamPartition = 0 }: Todo) {
     if (streamId == null) { throw new Error(`StreamKey: invalid streamId (${typeof streamId}): ${streamId}`) }
@@ -19,7 +20,7 @@ export function StreamKey({ streamId, streamPartition = 0 }: Todo) {
     return `${streamId}::${streamPartition}`
 }
 
-export function validateOptions(optionsOrStreamId: Todo): Todo {
+export function validateOptions(optionsOrStreamId: StreamPartDefinition): ValidatedStreamPartDefinition {
     if (!optionsOrStreamId) {
         throw new Error('streamId is required!')
     }

--- a/src/subscribe/index.ts
+++ b/src/subscribe/index.ts
@@ -127,8 +127,8 @@ export class Subscription extends Emitter {
     }
 
     // TODO should we expose this to the user as no-args method?
-    async unsubscribe(...args: Todo[]) {
-        return this.cancel(...args)
+    async unsubscribe() {
+        return this.cancel()
     }
 }
 

--- a/src/subscribe/index.ts
+++ b/src/subscribe/index.ts
@@ -84,7 +84,7 @@ export class Subscription extends Emitter {
      * Collect all messages into an array.
      * Returns array when subscription is ended.
      */
-    async collect(n?: Todo) {
+    async collect(n?: number) {
         const msgs = []
         for await (const msg of this) {
             if (n === 0) {
@@ -126,6 +126,7 @@ export class Subscription extends Emitter {
         return this.pipeline.throw(...args)
     }
 
+    // TODO should we expose this to the user as no-args method?
     async unsubscribe(...args: Todo[]) {
         return this.cancel(...args)
     }

--- a/src/subscribe/index.ts
+++ b/src/subscribe/index.ts
@@ -11,7 +11,7 @@ import Validator from './Validator'
 import messageStream from './messageStream'
 import resendStream from './resendStream'
 import { Todo } from '../types'
-import StreamrClient from '..'
+import StreamrClient, { StreamPartDefinition } from '..'
 
 export class Subscription extends Emitter {
 
@@ -441,7 +441,7 @@ class Subscriptions {
     /**
      * Remove all subscriptions, optionally only those matching options.
      */
-    async removeAll(options?: Todo) {
+    async removeAll(options?: StreamPartDefinition) {
         const subs = this.get(options)
         return allSettledValues(subs.map((sub: Todo) => (
             this.remove(sub)
@@ -464,7 +464,7 @@ class Subscriptions {
      * Count all matching subscriptions.
      */
 
-    count(options: Todo) {
+    count(options?: StreamPartDefinition) {
         if (options === undefined) { return this.countAll() }
         return this.get(options).length
     }
@@ -493,7 +493,7 @@ class Subscriptions {
      * Get all subscriptions matching options.
      */
 
-    get(options: Todo) {
+    get(options?: StreamPartDefinition) {
         if (options === undefined) { return this.getAll() }
 
         const { key } = validateOptions(options)
@@ -522,12 +522,11 @@ export class Subscriber {
         return this.subscriptions.getSubscriptionSession(...args)
     }
 
-    getAll(...args: Todo[]) {
-        // @ts-expect-error
-        return this.subscriptions.getAll(...args)
+    getAll() {
+        return this.subscriptions.getAll()
     }
 
-    count(options: Todo[]) {
+    count(options?: StreamPartDefinition) {
         return this.subscriptions.count(options)
     }
 
@@ -570,6 +569,7 @@ export class Subscriber {
         const options = validateOptions(opts)
 
         const resendMessageStream = resendStream(this.client, options)
+        // @ts-expect-error
         const realtimeMessageStream = messageStream(this.client.connection, options)
 
         // cancel both streams on end

--- a/src/subscribe/index.ts
+++ b/src/subscribe/index.ts
@@ -11,7 +11,7 @@ import Validator from './Validator'
 import messageStream from './messageStream'
 import resendStream from './resendStream'
 import { Todo } from '../types'
-import StreamrClient, { StreamPartDefinition } from '..'
+import StreamrClient, { StreamPartDefinition, SubscribeOptions } from '..'
 
 export class Subscription extends Emitter {
 
@@ -375,7 +375,7 @@ class Subscriptions {
         this.subSessions = new Map()
     }
 
-    async add(opts: Todo, onFinally: Todo = async () => {}) {
+    async add(opts: StreamPartDefinition, onFinally: Todo = async () => {}) {
         const options = validateOptions(opts)
         const { key } = options
 
@@ -530,21 +530,23 @@ export class Subscriber {
         return this.subscriptions.count(options)
     }
 
-    async subscribe(...args: Todo[]) {
-        // @ts-expect-error
-        return this.subscriptions.add(...args)
+    async subscribe(opts: StreamPartDefinition, onFinally?: Todo) {
+        return this.subscriptions.add(opts, onFinally)
     }
 
-    async unsubscribe(options: Todo): Promise<Todo> {
+    async unsubscribe(options: Subscription | StreamPartDefinition | { options: Subscription|StreamPartDefinition }): Promise<Todo> {
         if (options instanceof Subscription) {
             const sub = options
             return sub.cancel()
         }
 
+        // @ts-expect-error
         if (options && options.options) {
+            // @ts-expect-error
             return this.unsubscribe(options.options)
         }
 
+        // @ts-expect-error
         return this.subscriptions.removeAll(options)
     }
 
@@ -563,7 +565,7 @@ export class Subscriber {
         return sub
     }
 
-    async resendSubscribe(opts: Todo, onMessage: Todo) {
+    async resendSubscribe(opts: SubscribeOptions & StreamPartDefinition, onMessage: Todo) {
         // This works by passing a custom message stream to a subscription
         // the custom message stream iterates resends, then iterates realtime
         const options = validateOptions(opts)
@@ -644,6 +646,7 @@ export class Subscriber {
         const resendTask = resendMessageStream.subscribe()
         const realtimeTask = this.subscribe({
             ...options,
+            // @ts-expect-error
             msgStream: it,
             afterSteps: [
                 async function* detectEndOfResend(src: Todo) {

--- a/test/unit/StreamUtils.test.ts
+++ b/test/unit/StreamUtils.test.ts
@@ -1,0 +1,50 @@
+import { Stream } from '../../src/stream'
+import { validateOptions } from '../../src/stream/utils'
+
+describe('Stream utils', () => {
+
+    it('no definition', () => {
+        expect(() => validateOptions(undefined)).toThrow()
+        expect(() => validateOptions(null)).toThrow()
+        expect(() => validateOptions({})).toThrow()
+    })
+
+    it('string', () => {
+        expect(validateOptions('foo')).toMatchObject({
+            streamId: 'foo',
+            streamPartition: 0,
+            key: 'foo::0'
+        })
+    })
+
+    it('object', () => {
+        expect(validateOptions({ streamId: 'foo' })).toMatchObject({
+            streamId: 'foo',
+            streamPartition: 0,
+            key: 'foo::0'
+        })
+        expect(validateOptions({ streamId: 'foo', streamPartition: 123 })).toMatchObject({
+            streamId: 'foo',
+            streamPartition: 123,
+            key: 'foo::123'
+        })
+        expect(validateOptions({ id: 'foo', partition: 123 })).toMatchObject({
+            streamId: 'foo',
+            streamPartition: 123,
+            key: 'foo::123'
+        })
+    })
+
+    it('stream', () => {
+        const stream = new Stream(undefined as any, {
+            id: 'foo',
+            name: 'bar'
+        })
+        expect(validateOptions({ stream })).toMatchObject({
+            streamId: 'foo',
+            streamPartition: 0,
+            key: 'foo::0'
+        })
+    })
+
+})

--- a/test/unit/StreamUtils.test.ts
+++ b/test/unit/StreamUtils.test.ts
@@ -4,8 +4,8 @@ import { validateOptions } from '../../src/stream/utils'
 describe('Stream utils', () => {
 
     it('no definition', () => {
-        expect(() => validateOptions(undefined)).toThrow()
-        expect(() => validateOptions(null)).toThrow()
+        expect(() => validateOptions(undefined as any)).toThrow()
+        expect(() => validateOptions(null as any)).toThrow()
         expect(() => validateOptions({})).toThrow()
     })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -76,6 +76,7 @@ export function getWaitForStorage(client: StreamrClient, defaultOpts = {}) {
     /* eslint-disable no-await-in-loop */
     return async (publishRequest: any, opts = {}) => {
         const {
+            // @ts-expect-error
             streamId, streamPartition = 0, interval = 500, timeout = 5000, count = 100, messageMatchFn = defaultMessageMatchFn
         } = validateOptions({
             ...defaultOpts,
@@ -145,15 +146,25 @@ export function getPublishTestMessages(client: StreamrClient, defaultOpts = {}) 
         const {
             streamId,
             streamPartition = 0,
+            // @ts-expect-error
             delay = 100,
+            // @ts-expect-error
             timeout = 3500,
+            // @ts-expect-error
             waitForLast = false, // wait for message to hit storage
+            // @ts-expect-error
             waitForLastCount,
+            // @ts-expect-error
             waitForLastTimeout,
+            // @ts-expect-error
             beforeEach = (m: any) => m,
+            // @ts-expect-error
             afterEach = () => {},
+            // @ts-expect-error
             timestamp,
+            // @ts-expect-error
             partitionKey,
+            // @ts-expect-error
             createMessage = () => {
                 msgCount += 1
                 return {


### PR DESCRIPTION
Define valid types for public API methods

Also small bug fix for parsing stream definition options (e.g. when filtering subscriptions with `getSubscription(opts)`)