### PR TITLE
Fix: DU withdraw amount as string

### DIFF
--- a/src/dataunion/DataUnion.ts
+++ b/src/dataunion/DataUnion.ts
@@ -235,7 +235,7 @@ export class DataUnion {
     /** @internal */
     async _createWithdrawSignature(amountTokenWei: BigNumber|number|string, to: EthereumAddress, withdrawn: BigNumber, signer: JsonRpcSigner) {
         // @ts-expect-error
-        const message = to + hexZeroPad(amountTokenWei, 32).slice(2) + this.getSidechainAddress().slice(2) + hexZeroPad(withdrawn, 32).slice(2)
+        const message = to + hexZeroPad(BigNumber.from(amountTokenWei), 32).slice(2) + this.getSidechainAddress().slice(2) + hexZeroPad(withdrawn, 32).slice(2)
         const signature = await signer.signMessage(arrayify(message))
         return signature
     }

--- a/src/dataunion/DataUnion.ts
+++ b/src/dataunion/DataUnion.ts
@@ -234,8 +234,7 @@ export class DataUnion {
 
     /** @internal */
     async _createWithdrawSignature(amountTokenWei: BigNumber|number|string, to: EthereumAddress, withdrawn: BigNumber, signer: JsonRpcSigner) {
-        // @ts-expect-error
-        const message = to + hexZeroPad(BigNumber.from(amountTokenWei), 32).slice(2) + this.getSidechainAddress().slice(2) + hexZeroPad(withdrawn, 32).slice(2)
+        const message = to + hexZeroPad(BigNumber.from(amountTokenWei).toHexString(), 32).slice(2) + this.getSidechainAddress().slice(2) + hexZeroPad(withdrawn.toHexString(), 32).slice(2)
         const signature = await signer.signMessage(arrayify(message))
         return signature
     }

--- a/src/dataunion/DataUnion.ts
+++ b/src/dataunion/DataUnion.ts
@@ -2,7 +2,7 @@ import { getAddress } from '@ethersproject/address'
 import { BigNumber } from '@ethersproject/bignumber'
 import { arrayify, hexZeroPad } from '@ethersproject/bytes'
 import { Contract } from '@ethersproject/contracts'
-import { TransactionReceipt, TransactionResponse } from '@ethersproject/providers'
+import { JsonRpcSigner, TransactionReceipt, TransactionResponse } from '@ethersproject/providers'
 import debug from 'debug'
 import { Contracts } from './Contracts'
 import { StreamrClient } from '../StreamrClient'
@@ -229,8 +229,13 @@ export class DataUnion {
         const memberData = await duSidechain.memberData(address)
         if (memberData[0] === '0') { throw new Error(`${address} is not a member in Data Union (sidechain address ${duSidechain.address})`) }
         const withdrawn = memberData[3]
+        return this._createWithdrawSignature(amountTokenWei, to, withdrawn, signer)
+    }
+
+    /** @internal */
+    async _createWithdrawSignature(amountTokenWei: BigNumber|number|string, to: EthereumAddress, withdrawn: BigNumber, signer: JsonRpcSigner) {
         // @ts-expect-error
-        const message = to + hexZeroPad(amountTokenWei, 32).slice(2) + duSidechain.address.slice(2) + hexZeroPad(withdrawn, 32).slice(2)
+        const message = to + hexZeroPad(amountTokenWei, 32).slice(2) + this.getSidechainAddress().slice(2) + hexZeroPad(withdrawn, 32).slice(2)
         const signature = await signer.signMessage(arrayify(message))
         return signature
     }

--- a/src/dataunion/DataUnion.ts
+++ b/src/dataunion/DataUnion.ts
@@ -233,8 +233,16 @@ export class DataUnion {
     }
 
     /** @internal */
-    async _createWithdrawSignature(amountTokenWei: BigNumber|number|string, to: EthereumAddress, withdrawn: BigNumber, signer: JsonRpcSigner) {
-        const message = to + hexZeroPad(BigNumber.from(amountTokenWei).toHexString(), 32).slice(2) + this.getSidechainAddress().slice(2) + hexZeroPad(withdrawn.toHexString(), 32).slice(2)
+    async _createWithdrawSignature(
+        amountTokenWei: BigNumber|number|string,
+        to: EthereumAddress,
+        withdrawn: BigNumber,
+        signer: JsonRpcSigner
+    ) {
+        const message = to
+            + hexZeroPad(BigNumber.from(amountTokenWei).toHexString(), 32).slice(2)
+            + this.getSidechainAddress().slice(2)
+            + hexZeroPad(withdrawn.toHexString(), 32).slice(2)
         const signature = await signer.signMessage(arrayify(message))
         return signature
     }

--- a/test/integration/dataunion/signature.test.ts
+++ b/test/integration/dataunion/signature.test.ts
@@ -75,7 +75,7 @@ describe('DataUnion signature', () => {
         expect(isValid3).toBe(true)
     }, 100000)
 
-    it('create signatute', async () => {
+    it('create signature', async () => {
         const client = new StreamrClient({
             auth: {
                 privateKey: '0x1111111111111111111111111111111111111111111111111111111111111111'

--- a/test/integration/dataunion/signature.test.ts
+++ b/test/integration/dataunion/signature.test.ts
@@ -84,10 +84,11 @@ describe('DataUnion signature', () => {
         const dataUnion = client.getDataUnion('0x2222222222222222222222222222222222222222')
         const to = '0x3333333333333333333333333333333333333333'
         const withdrawn = BigNumber.from('4000000000000000')
-        // 0.005 tokens
-        for (const amount of [5000000000000000, '5000000000000000', BigNumber.from('5000000000000000')]) {
-            const signature = await dataUnion._createWithdrawSignature(amount, to, withdrawn, client.ethereum.getSigner())
-            expect(signature).toBe('0x5325ae62cdfd7d7c15101c611adcb159439217a48193c4e1d87ca5de698ec5233b1a68fd1302fdbd5450618d40739904295c88e88cf79d4241cf8736c2ec75731b')
-        }
+        const amounts = [5000000000000000, '5000000000000000', BigNumber.from('5000000000000000')]
+        // eslint-disable-next-line no-underscore-dangle
+        const signaturePromises = amounts.map((amount) => dataUnion._createWithdrawSignature(amount, to, withdrawn, client.ethereum.getSigner()))
+        const actualSignatures = await Promise.all(signaturePromises)
+        const expectedSignature = '0x5325ae62cdfd7d7c15101c611adcb159439217a48193c4e1d87ca5de698ec5233b1a68fd1302fdbd5450618d40739904295c88e88cf79d4241cf8736c2ec75731b' // eslint-disable-line max-len
+        expect(actualSignatures.every((actual) => actual === expectedSignature))
     })
 })

--- a/test/integration/dataunion/signature.test.ts
+++ b/test/integration/dataunion/signature.test.ts
@@ -1,4 +1,4 @@
-import { Contract, providers, Wallet } from 'ethers'
+import { BigNumber, Contract, providers, Wallet } from 'ethers'
 import { parseEther } from 'ethers/lib/utils'
 import debug from 'debug'
 
@@ -74,4 +74,20 @@ describe('DataUnion signature', () => {
         expect(isValid2).toBe(true)
         expect(isValid3).toBe(true)
     }, 100000)
+
+    it('create signatute', async () => {
+        const client = new StreamrClient({
+            auth: {
+                privateKey: '0x1111111111111111111111111111111111111111111111111111111111111111'
+            }
+        })
+        const dataUnion = client.getDataUnion('0x2222222222222222222222222222222222222222')
+        const to = '0x3333333333333333333333333333333333333333'
+        const withdrawn = BigNumber.from('4000000000000000')
+        // 0.005 tokens
+        for (const amount of [5000000000000000, '5000000000000000', BigNumber.from('5000000000000000')]) {
+            const signature = await dataUnion._createWithdrawSignature(amount, to, withdrawn, client.ethereum.getSigner())
+            expect(signature).toBe('0x5325ae62cdfd7d7c15101c611adcb159439217a48193c4e1d87ca5de698ec5233b1a68fd1302fdbd5450618d40739904295c88e88cf79d4241cf8736c2ec75731b')
+        }
+    })
 })


### PR DESCRIPTION
Bug fix for `DataUnion.signWithdrawAmountTo()`. 

The `amountTokenWei` parameter  is typed as` BigNumber|number|string`, but it if the value is a string the method throws an error: `invalid hex string (argument="value", value="...", code=INVALID_ARGUMENT, version=bytes/5.0.10)`. Fixed the parameter handling by converting the given value to a `BigNumber`. 

Fixed also a TypeScript warning by reading the value from `BigNumber` via `toHexString()` method (which is what the previous implementation did implicitly).
