### PR TITLE
fix: strip ansi-colors to get the branch name correctly

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/bin/sh
-BRANCH_NAME=$(git branch --no-color | grep --color=never '*' | sed 's/* //')
+BRANCH_NAME=$(git symbolic-ref --short -q HEAD)
 
 if [ $BRANCH_NAME != '(no branch)' ]
 then

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/bin/sh
-BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
+BRANCH_NAME=$(git branch | grep '*' | sed 's/.*\*.* //')
 
 if [ $BRANCH_NAME != '(no branch)' ]
 then

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/bin/sh
-BRANCH_NAME=$(git branch | grep '*' | sed 's/.*\*.* //')
+BRANCH_NAME=$(git branch --no-color | grep --color=never '*' | sed 's/* //')
 
 if [ $BRANCH_NAME != '(no branch)' ]
 then


### PR DESCRIPTION
I got an error like this:
```
$ git commit
.husky/commit-msg: line 4: [: too many arguments
```
the commit went through but without the check

the reason I think is that my `git branch` adds colors, so this new sed magic now strips that ansi-coloring.